### PR TITLE
feat(go-backend): change Post ID generation to UUID v7 (#56)

### DIFF
--- a/go-backend/internal/domain/entity/post.go
+++ b/go-backend/internal/domain/entity/post.go
@@ -42,7 +42,7 @@ func (p *postImpl) CreatedAt() time.Time {
 
 // NewPost creates a new Post with a generated UUID, validating the content.
 func NewPost(userId uuid.UUID, content string, createdAt time.Time) (Post, error) {
-	id, err := uuid.NewRandom()
+	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, err
 	}

--- a/go-backend/internal/domain/entity/post_test.go
+++ b/go-backend/internal/domain/entity/post_test.go
@@ -63,6 +63,28 @@ func TestNewPost_FailureCase(t *testing.T) {
 	}
 }
 
+func TestNewPost_GeneratesUuidV7(t *testing.T) {
+	t.Run("generated id has UUID version 7", func(t *testing.T) {
+		userId := uuid.New()
+		post, err := entity.NewPost(userId, "some content", time.Now())
+
+		require.NoError(t, err)
+		assert.Equal(t, uuid.Version(7), post.Id().Version())
+	})
+
+	t.Run("consecutively generated ids are time-ordered", func(t *testing.T) {
+		userId := uuid.New()
+		post1, err1 := entity.NewPost(userId, "first post", time.Now())
+		post2, err2 := entity.NewPost(userId, "second post", time.Now())
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		// UUID v7 bytes are lexicographically sortable by creation time
+		assert.True(t, post1.Id().String() < post2.Id().String() || post1.Id().String() == post2.Id().String(),
+			"first post ID should be <= second post ID in lexicographic order")
+	})
+}
+
 func TestReconstructPost_HappyCase(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## 概要

Post エンティティの ID 生成を UUID v4 (`uuid.NewRandom`) から UUID v7 (`uuid.NewV7`) に変更。UUID v7 は Unix timestamp ベースで時系列ソートが可能になる。

## 変更内容

- `go-backend/internal/domain/entity/post.go`: `NewPost()` 内の `uuid.NewRandom()` → `uuid.NewV7()` に変更
- `go-backend/internal/domain/entity/post_test.go`: UUID v7 を検証するテストを追加
  - `TestNewPost_GeneratesUuidV7`: version bit が 7 であること、連続生成 ID が時系列順であることを確認

## テスト証跡

```
make fmt   → 0 issues
make lint  → 0 issues
make test-unit → all packages PASS
```

## 関連

Closes #56