### PR TITLE
chore(go-backend): enable depguard to enforce Clean Architecture import boundaries

### DIFF
--- a/go-backend/.golangci.toml
+++ b/go-backend/.golangci.toml
@@ -4,7 +4,6 @@ version = "2"
 default = "all"
 disable = [
   "wsl",
-  "depguard",
   "wrapcheck",
   "revive",
   "noinlineerr",
@@ -39,3 +38,29 @@ path = "internal/domain/vo/error.go"
 linters = [
   "mnd",
 ]
+
+# depguard: enforce Clean Architecture import boundaries (ADR-0004)
+[linters.settings.depguard.rules.domain-no-framework]
+  files = ["**/internal/domain/**"]
+  deny = [
+    {pkg = "github.com/labstack/echo", desc = "domain must not import echo; Echo types must stay in the HTTP adapter layer (ADR-0004)"},
+    {pkg = "github.com/google/wire", desc = "domain must not import wire; wire is reserved for the composition root (ADR-0004)"},
+    {pkg = "github.com/jackc/pgx", desc = "domain must not import pgx; DB access belongs in the infrastructure layer (ADR-0004)"},
+    {pkg = "github.com/jackc/pgconn", desc = "domain must not import pgconn (ADR-0004)"},
+    {pkg = "github.com/jackc/pgtype", desc = "domain must not import pgtype (ADR-0004)"},
+    {pkg = "database/sql", desc = "domain must not import database/sql; DB access belongs in the infrastructure layer (ADR-0004)"},
+    {pkg = "github.com/Haya372/web-app-template/go-backend/internal/usecase", desc = "domain must not depend on usecase; dependency must flow inward only (ADR-0004)"},
+    {pkg = "github.com/Haya372/web-app-template/go-backend/internal/infrastructure", desc = "domain must not depend on infrastructure; dependency must flow inward only (ADR-0004)"},
+  ]
+
+[linters.settings.depguard.rules.usecase-no-framework]
+  files = ["**/internal/usecase/**"]
+  deny = [
+    {pkg = "github.com/labstack/echo", desc = "usecase must not import echo; Echo types must stay in the HTTP adapter layer (ADR-0004)"},
+    {pkg = "github.com/google/wire", desc = "usecase must not import wire; wire is reserved for the composition root (ADR-0004)"},
+    {pkg = "github.com/jackc/pgx", desc = "usecase must not import pgx; DB access belongs in the infrastructure layer (ADR-0004)"},
+    {pkg = "github.com/jackc/pgconn", desc = "usecase must not import pgconn (ADR-0004)"},
+    {pkg = "github.com/jackc/pgtype", desc = "usecase must not import pgtype (ADR-0004)"},
+    {pkg = "database/sql", desc = "usecase must not import database/sql; DB access belongs in the infrastructure layer (ADR-0004)"},
+    {pkg = "github.com/Haya372/web-app-template/go-backend/internal/infrastructure", desc = "usecase must not depend on infrastructure; dependency must flow inward only (ADR-0004)"},
+  ]

--- a/go-backend/CLAUDE.md
+++ b/go-backend/CLAUDE.md
@@ -61,6 +61,9 @@ infrastructure (adapters) → usecase → domain
 - HTTP error responses: `application/problem+json` with stable `type`/`title`/`status` fields; no internal diagnostics in public payloads (ADR-0006)
 - Transactions start in `usecase` via `TransactionManager.Do`, propagate via `context`; nested `TransactionManager.Do` calls are forbidden (ADR-0007)
 - `wire` is used only at the composition root (`cmd/`)
+- **depguard enforces import boundaries at lint time** — violations in `internal/domain` or `internal/usecase` cause `make lint` to fail:
+  - `internal/domain/**` must not import `echo`, `wire`, `pgx`/`pgconn`/`pgtype`, `database/sql`, `internal/usecase`, or `internal/infrastructure`
+  - `internal/usecase/**` must not import `echo`, `wire`, `pgx`/`pgconn`/`pgtype`, `database/sql`, or `internal/infrastructure`
 
 **Code generation:**
 


### PR DESCRIPTION
## 背景・目的

ADR-0004 で依存方向 `infrastructure → usecase → domain` が定められているが、`.golangci.toml` で `depguard` が無効化されており、レイヤー境界違反を静的解析で検出できない状態だった。Echo 型や pgx が `usecase`/`domain` へ漏れるリスクをコードレビューのみに頼っていたため、CI で自動検出できるようにする。（#84）

## 変更内容

- `go-backend/.golangci.toml`: `depguard` を `disable` リストから削除し、レイヤー別禁止ルールを追加
  - `internal/domain/**`: `echo`/`wire`/`pgx`/`pgconn`/`pgtype`/`database/sql`/`internal/usecase`/`internal/infrastructure` のインポートを禁止
  - `internal/usecase/**`: `echo`/`wire`/`pgx`/`pgconn`/`pgtype`/`database/sql`/`internal/infrastructure` のインポートを禁止
- `go-backend/CLAUDE.md`: **Key constraints** セクションに depguard による import 制限ルールを追記

## テスト実施結果

| ターゲット | 結果 |
|---|---|
| `golangci-lint run -c .golangci.toml` | ✅ 0 issues |
| `go test ./...` | ✅ 全パス |

境界違反の検出動作も確認済み:
- `internal/domain` に `echo/v5` を追加 → `depguard` エラーで lint 失敗 ✅
- `internal/domain` に `pgx/v5` を追加 → `depguard` エラーで lint 失敗 ✅
- `internal/usecase` に `internal/infrastructure` を追加 → lint 失敗 ✅

## 関連 issue

Closes #84

## ADR / ドキュメント更新

- `go-backend/CLAUDE.md` の Key constraints に depguard ルールを追記（ADR-0004 準拠）

## 破壊的変更

なし