### PR TITLE
test(go-backend): expand integration test coverage

### DIFF
--- a/go-backend/internal/infrastructure/http/posts_router_test.go
+++ b/go-backend/internal/infrastructure/http/posts_router_test.go
@@ -119,6 +119,71 @@ func TestListPosts(t *testing.T) {
 		err = testDb.Cleanup()
 		require.NoError(t, err)
 	})
+
+	t.Run("all posts appear regardless of authenticated user", func(t *testing.T) {
+		tokenA, _ := signupAndGetToken(t, "multiuser-a@example.com", "")
+		tokenB, _ := signupAndGetToken(t, "multiuser-b@example.com", "")
+		c := newTestClient()
+
+		// User A creates a post
+		createResp, err := c.PostV1PostsWithResponse(
+			context.Background(),
+			clientgen.CreatePostRequest{Content: "Post by user A"},
+			withBearerToken(tokenA),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, createResp.StatusCode())
+		postID := createResp.JSON201.Id
+
+		// User B fetches all posts — should include User A's post (no user filtering, Issue #58)
+		resp, err := c.GetV1PostsWithResponse(context.Background(), nil, withBearerToken(tokenB))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+		require.NotNil(t, resp.JSON200)
+		require.GreaterOrEqual(t, resp.JSON200.Total, 1)
+
+		found := false
+		for _, p := range resp.JSON200.Posts {
+			if p.Id == postID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "User A's post should be visible to User B")
+
+		err = testDb.Cleanup()
+		require.NoError(t, err)
+	})
+
+	t.Run("pagination with offset returns correct subset", func(t *testing.T) {
+		token, _ := signupAndGetToken(t, "offset-user@example.com", "")
+		c := newTestClient()
+
+		for range 3 {
+			_, err := c.PostV1PostsWithResponse(
+				context.Background(),
+				clientgen.CreatePostRequest{Content: "post content"},
+				withBearerToken(token),
+			)
+			require.NoError(t, err)
+		}
+
+		offset := 2
+		limit := 10
+		resp, err := c.GetV1PostsWithResponse(
+			context.Background(),
+			&clientgen.GetV1PostsParams{Offset: &offset, Limit: &limit},
+			withBearerToken(token),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+		require.NotNil(t, resp.JSON200)
+		assert.Equal(t, 3, resp.JSON200.Total)
+		assert.Len(t, resp.JSON200.Posts, 1)
+
+		err = testDb.Cleanup()
+		require.NoError(t, err)
+	})
 }
 
 func TestCreatePost(t *testing.T) {
@@ -189,4 +254,39 @@ func TestCreatePost(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+
+	t.Run("invalid JWT returns 401", func(t *testing.T) {
+		resp, err := newTestClient().PostV1PostsWithResponse(
+			context.Background(),
+			clientgen.CreatePostRequest{Content: "test"},
+			withBearerToken("invalid-token-string"),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode())
+		require.NotNil(t, resp.ApplicationproblemJSON401)
+		assert.Equal(t, "UNAUTHORIZED", resp.ApplicationproblemJSON401.Type)
+
+		err = testDb.Cleanup()
+		require.NoError(t, err)
+	})
+
+	t.Run("response includes userId matching authenticated user", func(t *testing.T) {
+		token, userID := signupAndGetToken(t, "post-fields@example.com", "")
+		c := newTestClient()
+
+		resp, err := c.PostV1PostsWithResponse(
+			context.Background(),
+			clientgen.CreatePostRequest{Content: "field check"},
+			withBearerToken(token),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode())
+		require.NotNil(t, resp.JSON201)
+
+		assert.Equal(t, userID, resp.JSON201.UserId.String())
+		assert.NotZero(t, resp.JSON201.CreatedAt)
+
+		err = testDb.Cleanup()
+		require.NoError(t, err)
+	})
 }

--- a/go-backend/internal/infrastructure/http/users_router_test.go
+++ b/go-backend/internal/infrastructure/http/users_router_test.go
@@ -343,4 +343,48 @@ func TestListUsers(t *testing.T) {
 		err = testDb.Cleanup()
 		require.NoError(t, err)
 	})
+
+	t.Run("limit 101 returns 400", func(t *testing.T) {
+		token, _ := signupAndGetToken(t, "limit101@example.com", adminRoleID)
+		c := newTestClient()
+
+		limit := 101
+		resp, err := c.GetV1UsersWithResponse(
+			context.Background(),
+			&clientgen.GetV1UsersParams{Limit: &limit},
+			withBearerToken(token),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode())
+		require.NotNil(t, resp.ApplicationproblemJSON400)
+		assert.Equal(t, "VALIDATION_ERROR", resp.ApplicationproblemJSON400.Type)
+
+		err = testDb.Cleanup()
+		require.NoError(t, err)
+	})
+
+	t.Run("pagination with offset returns correct subset", func(t *testing.T) {
+		// Ensure a clean slate so the exact total=3 assertion is reliable.
+		require.NoError(t, testDb.Cleanup())
+		// 1 admin + 2 regular users = 3 total; offset=2 → 1 user returned
+		token, _ := signupAndGetToken(t, "offset-admin@example.com", adminRoleID)
+		signupAndGetToken(t, "offset-user1@example.com", "")
+		signupAndGetToken(t, "offset-user2@example.com", "")
+
+		offset := 2
+		limit := 10
+		resp, err := newTestClient().GetV1UsersWithResponse(
+			context.Background(),
+			&clientgen.GetV1UsersParams{Offset: &offset, Limit: &limit},
+			withBearerToken(token),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+		require.NotNil(t, resp.JSON200)
+		assert.Equal(t, 3, resp.JSON200.Total)
+		assert.Len(t, resp.JSON200.Users, 1)
+
+		err = testDb.Cleanup()
+		require.NoError(t, err)
+	})
 }

--- a/go-backend/internal/infrastructure/query/user_query_service_impl_test.go
+++ b/go-backend/internal/infrastructure/query/user_query_service_impl_test.go
@@ -107,3 +107,48 @@ func TestUserQueryService_FindAll_OrderedByCreatedAtDesc(t *testing.T) {
 	assert.Contains(t, emails, "first@example.com")
 	assert.Contains(t, emails, "second@example.com")
 }
+
+func TestUserQueryService_FindAll_BeyondOffsetReturnsEmpty(t *testing.T) {
+	defer func() { require.NoError(t, testDb.Cleanup()) }()
+
+	seedUser(t, "beyond@example.com")
+
+	svc := query.NewUserQueryService(testDb.DbManager())
+	users, total, err := svc.FindAll(context.Background(), 10, 100)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Empty(t, users)
+}
+
+func TestUserQueryService_FindAll_MapsFieldsCorrectly(t *testing.T) {
+	defer func() { require.NoError(t, testDb.Cleanup()) }()
+
+	created := seedUser(t, "mapping@example.com")
+
+	svc := query.NewUserQueryService(testDb.DbManager())
+	users, total, err := svc.FindAll(context.Background(), 10, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, users, 1)
+	assert.Equal(t, created.ID(), users[0].ID)
+	assert.Equal(t, "mapping@example.com", users[0].Email)
+	assert.Equal(t, "Test User", users[0].Name)
+	assert.Equal(t, vo.UserStatusActive.String(), users[0].Status)
+}
+
+func TestUserQueryService_FindAll_TotalAndCountAreConsistent(t *testing.T) {
+	defer func() { require.NoError(t, testDb.Cleanup()) }()
+
+	for i := range 3 {
+		seedUser(t, "user"+string(rune('a'+i))+"consistent@example.com")
+	}
+
+	svc := query.NewUserQueryService(testDb.DbManager())
+	users, total, err := svc.FindAll(context.Background(), 1, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Len(t, users, 1)
+}

--- a/go-backend/internal/infrastructure/repository/post_repository_impl_test.go
+++ b/go-backend/internal/infrastructure/repository/post_repository_impl_test.go
@@ -68,3 +68,50 @@ func TestCreatePost_HappyCase(t *testing.T) {
 
 	testDb.Cleanup()
 }
+
+func TestCreatePost_ForeignKeyViolation(t *testing.T) {
+	defer func() { require.NoError(t, testDb.Cleanup()) }()
+
+	// Use a random UUID that has no corresponding user row to trigger a FK violation.
+	nonExistentUserID := uuid.New()
+	post := entity.ReconstructPost(
+		uuid.New(),
+		nonExistentUserID,
+		"this should fail",
+		time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC),
+	)
+
+	target := repository.NewPostRepository(testDb.DbManager())
+	_, err := target.Create(context.Background(), post)
+
+	require.Error(t, err)
+}
+
+func TestCreatePost_DuplicateID(t *testing.T) {
+	defer func() { require.NoError(t, testDb.Cleanup()) }()
+
+	user := seedUser(t)
+	fixedID := uuid.New()
+
+	post := entity.ReconstructPost(
+		fixedID,
+		user.ID(),
+		"first post",
+		time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC),
+	)
+
+	target := repository.NewPostRepository(testDb.DbManager())
+
+	_, err := target.Create(context.Background(), post)
+	require.NoError(t, err)
+
+	duplicate := entity.ReconstructPost(
+		fixedID,
+		user.ID(),
+		"duplicate post",
+		time.Date(2026, 3, 8, 13, 0, 0, 0, time.UTC),
+	)
+	_, err = target.Create(context.Background(), duplicate)
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
## 背景・目的

Go バックエンドの integration test において、HTTP・repository・query の各レイヤーで未カバーのシナリオが存在していた（#124）。本 PR ではプロダクションコードを変更せず、テストコードのみを追加して網羅性を向上させる。

## 変更内容

- **`posts_router_test.go`（4ケース追加）**
  - `TestListPosts`: ユーザー分離なし（全投稿共有）の確認テスト（Issue #58 仕様準拠）
  - `TestListPosts`: offset ページネーション（3件投稿後に `offset=2&limit=10` で1件返ること）
  - `TestCreatePost`: 無効な JWT での 401 レスポンス確認
  - `TestCreatePost`: レスポンスの `userId` が認証ユーザー ID と一致することの確認
- **`users_router_test.go`（2ケース追加）**
  - `TestListUsers`: `limit=101` で 400 VALIDATION_ERROR が返ること（境界値テスト）
  - `TestListUsers`: offset ページネーション（3ユーザー登録後に `offset=2&limit=10` で1件返ること）
- **`post_repository_impl_test.go`（2ケース追加）**
  - `TestCreatePost_ForeignKeyViolation`: 存在しない `user_id` を指定した際の FK 違反エラー確認
  - `TestCreatePost_DuplicateID`: 同一 ID での 2 回目の `Create` がエラーを返すことの確認
- **`user_query_service_impl_test.go`（3ケース追加）**
  - `TestUserQueryService_FindAll_BeyondOffsetReturnsEmpty`: offset がレコード数を超えた場合に空リストを返すこと
  - `TestUserQueryService_FindAll_MapsFieldsCorrectly`: DTO フィールド（ID・Email・Name・Status）のマッピング精度検証
  - `TestUserQueryService_FindAll_TotalAndCountAreConsistent`: `limit=1` 取得時に `total` がシード数を反映すること

## テスト実施結果

| コマンド | 結果 |
|---|---|
| `golangci-lint run` | ✅ 0 issues |
| `go test ./...` | ✅ 全パッケージ PASS |
| `go test ./... -tags=integration` | ✅ 全パッケージ PASS（新規11ケース含む） |

## 関連 issue

Closes #124

## ADR / ドキュメント更新

なし（テストコードのみの変更）

## 破壊的変更

なし