### PR TITLE
chore: consolidate Biome and ESLint base config to repo root

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,7 @@
         "api.github.com",
         "api.anthropic.com"
       ]
-    }
+    },
+    "enableWeakerNetworkIsolation": true
   }
 }

--- a/apps/react-frontend/biome.jsonc
+++ b/apps/react-frontend/biome.jsonc
@@ -1,12 +1,7 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
-	"vcs": {
-		"enabled": false,
-		"clientKind": "git",
-		"useIgnoreFile": false
-	},
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+	"extends": ["../../biome.jsonc"],
 	"files": {
-		"ignoreUnknown": false,
 		"includes": [
 			"**/src/**/*",
 			"**/.vscode/**/*",
@@ -17,15 +12,8 @@
 			"!**/src/generated"
 		]
 	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab"
-	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
-		"enabled": true,
 		"rules": {
-			"recommended": true,
 			"style": {
 				"noNonNullAssertion": "error",
 				"noProcessEnv": "error"
@@ -39,11 +27,5 @@
 				"noMisusedPromises": "error"
 			}
 		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double"
-		}
 	}
 }
-

--- a/apps/react-frontend/eslint.config.mjs
+++ b/apps/react-frontend/eslint.config.mjs
@@ -8,6 +8,7 @@ import reactPlugin from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import unicornPlugin from "eslint-plugin-unicorn";
 import tseslint from "typescript-eslint";
+import { formattingRulesOff } from "../../eslint.config.base.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const featuresDir = join(__dirname, "src/features");
@@ -172,19 +173,8 @@ export default tseslint.config(
 
 	// ── Formatting rules OFF (Biome is the formatter) ────────────────────────
 	// Biome owns all formatting concerns: indentation, quotes, semicolons, etc.
-	// Disable any ESLint rules that would duplicate or conflict with Biome.
-	{
-		rules: {
-			indent: "off",
-			quotes: "off",
-			semi: "off",
-			"comma-dangle": "off",
-			"max-len": "off",
-			"object-curly-spacing": "off",
-			"arrow-parens": "off",
-			"space-before-function-paren": "off",
-		},
-	},
+	// Shared across all workspaces via the root eslint.config.base.mjs.
+	formattingRulesOff,
 
 	// ── Feature boundary imports (architecture enforcement) ───────────────────
 	...featureBoundaryConfigs,

--- a/apps/react-frontend/package.json
+++ b/apps/react-frontend/package.json
@@ -13,16 +13,15 @@
     "test": "vitest run",
     "test:agent": "vitest run --reporter=agent",
     "lint": "run-s lint:*",
-    "lint:biome": "biome check",
+    "lint:biome": "biome check src",
     "lint:eslint": "eslint src",
     "lint:knip": "knip",
     "lint-staged": "lint-staged",
     "fmt": "run-s fmt:*",
-    "fmt:biome": "biome check --write",
+    "fmt:biome": "biome check --write src",
     "fmt:eslint": "eslint --fix src",
     "fmt:knip": "knip --fix",
-    "typecheck": "tsc --noEmit",
-    "check": "biome check"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hey-api/openapi-ts": "0.94.5",

--- a/apps/react-frontend/package.json
+++ b/apps/react-frontend/package.json
@@ -13,12 +13,12 @@
     "test": "vitest run",
     "test:agent": "vitest run --reporter=agent",
     "lint": "run-s lint:*",
-    "lint:biome": "biome lint",
+    "lint:biome": "biome check",
     "lint:eslint": "eslint src",
     "lint:knip": "knip",
     "lint-staged": "lint-staged",
     "fmt": "run-s fmt:*",
-    "fmt:biome": "biome lint --write ./src",
+    "fmt:biome": "biome check --write",
     "fmt:eslint": "eslint --fix src",
     "fmt:knip": "knip --fix",
     "typecheck": "tsc --noEmit",
@@ -68,7 +68,7 @@
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
       "pnpm eslint --fix",
-      "pnpm biome lint --write"
+      "pnpm biome check --write"
     ]
   }
 }

--- a/apps/react-frontend/src/components/Footer.tsx
+++ b/apps/react-frontend/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
-  return (
-    <footer className="mt-20 border-t border-border px-4 py-8 text-center text-sm text-muted-foreground">
-      <p>&copy; {new Date().getFullYear()} Your name here.</p>
-    </footer>
-  )
+	return (
+		<footer className="mt-20 border-t border-border px-4 py-8 text-center text-sm text-muted-foreground">
+			<p>&copy; {new Date().getFullYear()} Your name here.</p>
+		</footer>
+	);
 }

--- a/apps/react-frontend/src/components/Header.tsx
+++ b/apps/react-frontend/src/components/Header.tsx
@@ -1,38 +1,38 @@
-import { Link } from '@tanstack/react-router'
-import ThemeToggle from './ThemeToggle'
+import { Link } from "@tanstack/react-router";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Header() {
-  return (
-    <header className="sticky top-0 z-50 border-b border-border bg-background/80 px-4 backdrop-blur">
-      <nav className="page-wrap flex items-center gap-4 py-3">
-        <Link
-          to="/"
-          className="text-sm font-semibold text-foreground no-underline"
-        >
-          App
-        </Link>
+	return (
+		<header className="sticky top-0 z-50 border-b border-border bg-background/80 px-4 backdrop-blur">
+			<nav className="page-wrap flex items-center gap-4 py-3">
+				<Link
+					to="/"
+					className="text-sm font-semibold text-foreground no-underline"
+				>
+					App
+				</Link>
 
-        <div className="flex items-center gap-4 text-sm font-medium">
-          <Link
-            to="/"
-            className="text-muted-foreground transition-colors hover:text-foreground [&.active]:text-foreground"
-            activeProps={{ className: 'active' }}
-          >
-            Home
-          </Link>
-          <Link
-            to="/login"
-            className="text-muted-foreground transition-colors hover:text-foreground [&.active]:text-foreground"
-            activeProps={{ className: 'active' }}
-          >
-            Login
-          </Link>
-        </div>
+				<div className="flex items-center gap-4 text-sm font-medium">
+					<Link
+						to="/"
+						className="text-muted-foreground transition-colors hover:text-foreground [&.active]:text-foreground"
+						activeProps={{ className: "active" }}
+					>
+						Home
+					</Link>
+					<Link
+						to="/login"
+						className="text-muted-foreground transition-colors hover:text-foreground [&.active]:text-foreground"
+						activeProps={{ className: "active" }}
+					>
+						Login
+					</Link>
+				</div>
 
-        <div className="ml-auto">
-          <ThemeToggle />
-        </div>
-      </nav>
-    </header>
-  )
+				<div className="ml-auto">
+					<ThemeToggle />
+				</div>
+			</nav>
+		</header>
+	);
 }

--- a/apps/react-frontend/src/components/ThemeToggle.tsx
+++ b/apps/react-frontend/src/components/ThemeToggle.tsx
@@ -1,57 +1,57 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react";
 
-type ThemeMode = 'light' | 'dark' | 'system'
+type ThemeMode = "light" | "dark" | "system";
 
 function getStoredMode(): ThemeMode {
-  if (typeof window === 'undefined') return 'system'
-  const stored = window.localStorage.getItem('theme')
-  if (stored === 'light' || stored === 'dark') return stored
-  return 'system'
+	if (typeof window === "undefined") return "system";
+	const stored = window.localStorage.getItem("theme");
+	if (stored === "light" || stored === "dark") return stored;
+	return "system";
 }
 
 function applyTheme(mode: ThemeMode) {
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-  const isDark = mode === 'dark' || (mode === 'system' && prefersDark)
-  document.documentElement.classList.toggle('dark', isDark)
-  document.documentElement.style.colorScheme = isDark ? 'dark' : 'light'
+	const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+	const isDark = mode === "dark" || (mode === "system" && prefersDark);
+	document.documentElement.classList.toggle("dark", isDark);
+	document.documentElement.style.colorScheme = isDark ? "dark" : "light";
 }
 
 export default function ThemeToggle() {
-  // Lazy initializer reads stored preference once on mount — avoids calling
-  // setState synchronously inside an effect (react-hooks/set-state-in-effect).
-  const [mode, setMode] = useState<ThemeMode>(() => getStoredMode())
+	// Lazy initializer reads stored preference once on mount — avoids calling
+	// setState synchronously inside an effect (react-hooks/set-state-in-effect).
+	const [mode, setMode] = useState<ThemeMode>(() => getStoredMode());
 
-  useEffect(() => {
-    applyTheme(mode)
-  }, [mode])
+	useEffect(() => {
+		applyTheme(mode);
+	}, [mode]);
 
-  useEffect(() => {
-    if (mode !== 'system') return
-    const media = window.matchMedia('(prefers-color-scheme: dark)')
-    const onChange = () => applyTheme('system')
-    media.addEventListener('change', onChange)
-    return () => media.removeEventListener('change', onChange)
-  }, [mode])
+	useEffect(() => {
+		if (mode !== "system") return;
+		const media = window.matchMedia("(prefers-color-scheme: dark)");
+		const onChange = () => applyTheme("system");
+		media.addEventListener("change", onChange);
+		return () => media.removeEventListener("change", onChange);
+	}, [mode]);
 
-  function cycle() {
-    const next: ThemeMode =
-      mode === 'light' ? 'dark' : mode === 'dark' ? 'system' : 'light'
-    setMode(next)
-    applyTheme(next)
-    window.localStorage.setItem('theme', next)
-  }
+	function cycle() {
+		const next: ThemeMode =
+			mode === "light" ? "dark" : mode === "dark" ? "system" : "light";
+		setMode(next);
+		applyTheme(next);
+		window.localStorage.setItem("theme", next);
+	}
 
-  const label = `Theme: ${mode}. Click to switch.`
+	const label = `Theme: ${mode}. Click to switch.`;
 
-  return (
-    <button
-      type="button"
-      onClick={cycle}
-      aria-label={label}
-      title={label}
-      className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-    >
-      {mode === 'system' ? 'System' : mode === 'dark' ? 'Dark' : 'Light'}
-    </button>
-  )
+	return (
+		<button
+			type="button"
+			onClick={cycle}
+			aria-label={label}
+			title={label}
+			className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+		>
+			{mode === "system" ? "System" : mode === "dark" ? "Dark" : "Light"}
+		</button>
+	);
 }

--- a/apps/react-frontend/src/features/auth/contexts/AuthContext.test.tsx
+++ b/apps/react-frontend/src/features/auth/contexts/AuthContext.test.tsx
@@ -8,10 +8,10 @@
  *  - @/utils/tokenStorage   getToken / saveToken / removeToken   vi.mock
  */
 
-import React, { act, useContext } from "react"
-import { createRoot } from "react-dom/client"
-import type { Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React, { act, useContext } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock functions (must be defined before vi.mock calls)
@@ -21,7 +21,7 @@ const { mockGetToken, mockSaveToken, mockRemoveToken } = vi.hoisted(() => ({
 	mockGetToken: vi.fn<() => string | null>(),
 	mockSaveToken: vi.fn<(token: string) => void>(),
 	mockRemoveToken: vi.fn<() => void>(),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -31,13 +31,13 @@ vi.mock("@/utils/tokenStorage", () => ({
 	getToken: mockGetToken,
 	saveToken: mockSaveToken,
 	removeToken: mockRemoveToken,
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { AuthContext, AuthProvider } from "./AuthContext"
+import { AuthContext, AuthProvider } from "./AuthContext";
 
 // ---------------------------------------------------------------------------
 // BareConsumer — renders context presence into a data attribute.
@@ -45,8 +45,12 @@ import { AuthContext, AuthProvider } from "./AuthContext"
 // ---------------------------------------------------------------------------
 
 function BareConsumer(): React.ReactElement {
-	const ctx = useContext(AuthContext)
-	return React.createElement("span", { "data-is-null": String(ctx === null) }, "bare")
+	const ctx = useContext(AuthContext);
+	return React.createElement(
+		"span",
+		{ "data-is-null": String(ctx === null) },
+		"bare",
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -65,19 +69,19 @@ function BareConsumer(): React.ReactElement {
 // ---------------------------------------------------------------------------
 
 function TestConsumer(): React.ReactElement {
-	const ctx = useContext(AuthContext)
+	const ctx = useContext(AuthContext);
 	if (ctx === null) {
-		return React.createElement("div", { "data-testid": "no-context" }, "no context")
+		return React.createElement(
+			"div",
+			{ "data-testid": "no-context" },
+			"no context",
+		);
 	}
-	const { token, isAuthenticated, login, logout } = ctx
+	const { token, isAuthenticated, login, logout } = ctx;
 	return React.createElement(
 		"div",
 		null,
-		React.createElement(
-			"span",
-			{ "data-testid": "token" },
-			token ?? "null",
-		),
+		React.createElement("span", { "data-testid": "token" }, token ?? "null"),
 		React.createElement(
 			"span",
 			{ "data-testid": "is-authenticated" },
@@ -101,40 +105,46 @@ function TestConsumer(): React.ReactElement {
 			},
 			"Logout",
 		),
-	)
+	);
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-let root: Root | null = null
-let container: HTMLDivElement | null = null
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
 
 async function mount(): Promise<void> {
-	const div = document.createElement("div")
-	document.body.append(div)
-	container = div
+	const div = document.createElement("div");
+	document.body.append(div);
+	container = div;
 	await act(async () => {
-		root = createRoot(div)
+		root = createRoot(div);
 		root.render(
-			React.createElement(AuthProvider, null, React.createElement(TestConsumer)),
-		)
-	})
+			React.createElement(
+				AuthProvider,
+				null,
+				React.createElement(TestConsumer),
+			),
+		);
+	});
 }
 
 function getSpanText(testId: string): string | null {
-	return container?.querySelector<HTMLElement>(`[data-testid="${testId}"]`)
-		?.textContent ?? null
+	return (
+		container?.querySelector<HTMLElement>(`[data-testid="${testId}"]`)
+			?.textContent ?? null
+	);
 }
 
 function clickButton(testId: string): Promise<void> {
 	return act(async () => {
 		const btn = container?.querySelector<HTMLButtonElement>(
 			`[data-testid="${testId}"]`,
-		)
-		btn?.click()
-	})
+		);
+		btn?.click();
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -143,25 +153,25 @@ function clickButton(testId: string): Promise<void> {
 
 afterEach(async () => {
 	if (root) {
-		const r = root
-		root = null
+		const r = root;
+		root = null;
 		await act(async () => {
-			r.unmount()
-		})
+			r.unmount();
+		});
 	}
-	container?.remove()
-	container = null
-})
+	container?.remove();
+	container = null;
+});
 
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	mockGetToken.mockReset()
-	mockSaveToken.mockReset()
-	mockRemoveToken.mockReset()
-})
+	mockGetToken.mockReset();
+	mockSaveToken.mockReset();
+	mockRemoveToken.mockReset();
+});
 
 // ---------------------------------------------------------------------------
 // Tests — initial state
@@ -169,37 +179,37 @@ beforeEach(() => {
 
 describe("AuthProvider — initial state", () => {
 	it("initializes token from localStorage when one exists", async () => {
-		mockGetToken.mockReturnValue("existing-token")
+		mockGetToken.mockReturnValue("existing-token");
 
-		await mount()
+		await mount();
 
-		expect(getSpanText("token")).toBe("existing-token")
-	})
+		expect(getSpanText("token")).toBe("existing-token");
+	});
 
 	it("initializes token as null when localStorage is empty", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		await mount()
+		await mount();
 
-		expect(getSpanText("token")).toBe("null")
-	})
+		expect(getSpanText("token")).toBe("null");
+	});
 
 	it("sets isAuthenticated to true when a token exists in localStorage", async () => {
-		mockGetToken.mockReturnValue("existing-token")
+		mockGetToken.mockReturnValue("existing-token");
 
-		await mount()
+		await mount();
 
-		expect(getSpanText("is-authenticated")).toBe("true")
-	})
+		expect(getSpanText("is-authenticated")).toBe("true");
+	});
 
 	it("sets isAuthenticated to false when localStorage is empty", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		await mount()
+		await mount();
 
-		expect(getSpanText("is-authenticated")).toBe("false")
-	})
-})
+		expect(getSpanText("is-authenticated")).toBe("false");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — login action
@@ -207,32 +217,32 @@ describe("AuthProvider — initial state", () => {
 
 describe("AuthProvider — login", () => {
 	it("updates the token state after calling login", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		await mount()
-		await clickButton("login-btn")
+		await mount();
+		await clickButton("login-btn");
 
-		expect(getSpanText("token")).toBe("new-token")
-	})
+		expect(getSpanText("token")).toBe("new-token");
+	});
 
 	it("calls saveToken with the provided token", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		await mount()
-		await clickButton("login-btn")
+		await mount();
+		await clickButton("login-btn");
 
-		expect(mockSaveToken).toHaveBeenCalledWith("new-token")
-	})
+		expect(mockSaveToken).toHaveBeenCalledWith("new-token");
+	});
 
 	it("sets isAuthenticated to true after login", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		await mount()
-		await clickButton("login-btn")
+		await mount();
+		await clickButton("login-btn");
 
-		expect(getSpanText("is-authenticated")).toBe("true")
-	})
-})
+		expect(getSpanText("is-authenticated")).toBe("true");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — logout action
@@ -240,32 +250,32 @@ describe("AuthProvider — login", () => {
 
 describe("AuthProvider — logout", () => {
 	it("clears the token state after calling logout", async () => {
-		mockGetToken.mockReturnValue("existing-token")
+		mockGetToken.mockReturnValue("existing-token");
 
-		await mount()
-		await clickButton("logout-btn")
+		await mount();
+		await clickButton("logout-btn");
 
-		expect(getSpanText("token")).toBe("null")
-	})
+		expect(getSpanText("token")).toBe("null");
+	});
 
 	it("calls removeToken when logout is invoked", async () => {
-		mockGetToken.mockReturnValue("existing-token")
+		mockGetToken.mockReturnValue("existing-token");
 
-		await mount()
-		await clickButton("logout-btn")
+		await mount();
+		await clickButton("logout-btn");
 
-		expect(mockRemoveToken).toHaveBeenCalledTimes(1)
-	})
+		expect(mockRemoveToken).toHaveBeenCalledTimes(1);
+	});
 
 	it("sets isAuthenticated to false after logout", async () => {
-		mockGetToken.mockReturnValue("existing-token")
+		mockGetToken.mockReturnValue("existing-token");
 
-		await mount()
-		await clickButton("logout-btn")
+		await mount();
+		await clickButton("logout-btn");
 
-		expect(getSpanText("is-authenticated")).toBe("false")
-	})
-})
+		expect(getSpanText("is-authenticated")).toBe("false");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — isAuthenticated derived from token
@@ -273,18 +283,18 @@ describe("AuthProvider — logout", () => {
 
 describe("AuthProvider — isAuthenticated reflects token", () => {
 	it("is false initially, becomes true after login, then false after logout", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		await mount()
-		expect(getSpanText("is-authenticated")).toBe("false")
+		await mount();
+		expect(getSpanText("is-authenticated")).toBe("false");
 
-		await clickButton("login-btn")
-		expect(getSpanText("is-authenticated")).toBe("true")
+		await clickButton("login-btn");
+		expect(getSpanText("is-authenticated")).toBe("true");
 
-		await clickButton("logout-btn")
-		expect(getSpanText("is-authenticated")).toBe("false")
-	})
-})
+		await clickButton("logout-btn");
+		expect(getSpanText("is-authenticated")).toBe("false");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — context value shape (type assertion without rendering)
@@ -294,13 +304,13 @@ describe("AuthContext — default value", () => {
 	it("has a null default value outside of AuthProvider", async () => {
 		// The default value passed to createContext is null; verify via a consumer
 		// rendered without wrapping AuthProvider.
-		const div = document.createElement("div")
-		document.body.append(div)
+		const div = document.createElement("div");
+		document.body.append(div);
 		await act(async () => {
-			createRoot(div).render(React.createElement(BareConsumer))
-		})
+			createRoot(div).render(React.createElement(BareConsumer));
+		});
 
-		expect(div.querySelector("[data-is-null='true']")).not.toBeNull()
-		div.remove()
-	})
-})
+		expect(div.querySelector("[data-is-null='true']")).not.toBeNull();
+		div.remove();
+	});
+});

--- a/apps/react-frontend/src/features/auth/contexts/AuthContext.tsx
+++ b/apps/react-frontend/src/features/auth/contexts/AuthContext.tsx
@@ -1,42 +1,38 @@
 import {
-	type ReactNode,
 	createContext,
+	type ReactNode,
 	useCallback,
 	useMemo,
 	useState,
-} from "react"
-import {
-	getToken,
-	removeToken,
-	saveToken,
-} from "@/utils/tokenStorage"
+} from "react";
+import { getToken, removeToken, saveToken } from "@/utils/tokenStorage";
 
 export interface AuthContextValue {
-	token: string | null
-	isAuthenticated: boolean
-	login: (token: string) => void
-	logout: () => void
+	token: string | null;
+	isAuthenticated: boolean;
+	login: (token: string) => void;
+	logout: () => void;
 }
 
-export const AuthContext = createContext<AuthContextValue | null>(null)
+export const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-	const [token, setToken] = useState<string | null>(() => getToken())
+	const [token, setToken] = useState<string | null>(() => getToken());
 
 	const login = useCallback((newToken: string) => {
-		saveToken(newToken)
-		setToken(newToken)
-	}, [])
+		saveToken(newToken);
+		setToken(newToken);
+	}, []);
 
 	const logout = useCallback(() => {
-		removeToken()
-		setToken(null)
-	}, [])
+		removeToken();
+		setToken(null);
+	}, []);
 
 	const value = useMemo<AuthContextValue>(
 		() => ({ token, isAuthenticated: token !== null, login, logout }),
 		[token, login, logout],
-	)
+	);
 
-	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/apps/react-frontend/src/features/auth/hooks/useAuth.test.tsx
+++ b/apps/react-frontend/src/features/auth/hooks/useAuth.test.tsx
@@ -9,10 +9,10 @@
  *    (required because AuthProvider imports tokenStorage at module load time)
  */
 
-import React, { act } from "react"
-import { createRoot } from "react-dom/client"
-import type { Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React, { act } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock functions (must be defined before vi.mock calls)
@@ -20,7 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const { mockGetToken } = vi.hoisted(() => ({
 	mockGetToken: vi.fn<() => string | null>(),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -30,14 +30,14 @@ vi.mock("@/utils/tokenStorage", () => ({
 	getToken: mockGetToken,
 	saveToken: vi.fn(),
 	removeToken: vi.fn(),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { AuthProvider } from "@/features/auth/contexts/AuthContext"
-import { useAuth } from "./useAuth"
+import { AuthProvider } from "@/features/auth/contexts/AuthContext";
+import { useAuth } from "./useAuth";
 
 // ---------------------------------------------------------------------------
 // Test components
@@ -48,39 +48,47 @@ import { useAuth } from "./useAuth"
 // ---------------------------------------------------------------------------
 
 function AuthConsumer(): React.ReactElement {
-	const { token, isAuthenticated, login, logout } = useAuth()
-	return React.createElement("span", {
-		"data-token": token ?? "null",
-		"data-is-authenticated": String(isAuthenticated),
-		"data-has-login": String(typeof login === "function"),
-		"data-has-logout": String(typeof logout === "function"),
-	}, "ok")
+	const { token, isAuthenticated, login, logout } = useAuth();
+	return React.createElement(
+		"span",
+		{
+			"data-token": token ?? "null",
+			"data-is-authenticated": String(isAuthenticated),
+			"data-has-login": String(typeof login === "function"),
+			"data-has-logout": String(typeof logout === "function"),
+		},
+		"ok",
+	);
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-let root: Root | null = null
-let container: HTMLDivElement | null = null
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
 
 function clearBody(): void {
 	while (document.body.firstChild) {
-		document.body.firstChild.remove()
+		document.body.firstChild.remove();
 	}
 }
 
 async function mountWithProvider(): Promise<HTMLDivElement> {
-	const div = document.createElement("div")
-	document.body.append(div)
-	container = div
+	const div = document.createElement("div");
+	document.body.append(div);
+	container = div;
 	await act(async () => {
-		root = createRoot(div)
+		root = createRoot(div);
 		root.render(
-			React.createElement(AuthProvider, null, React.createElement(AuthConsumer)),
-		)
-	})
-	return div
+			React.createElement(
+				AuthProvider,
+				null,
+				React.createElement(AuthConsumer),
+			),
+		);
+	});
+	return div;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,24 +97,24 @@ async function mountWithProvider(): Promise<HTMLDivElement> {
 
 afterEach(async () => {
 	if (root) {
-		const r = root
-		root = null
+		const r = root;
+		root = null;
 		await act(async () => {
-			r.unmount()
-		})
+			r.unmount();
+		});
 	}
-	container?.remove()
-	container = null
-	clearBody()
-})
+	container?.remove();
+	container = null;
+	clearBody();
+});
 
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	mockGetToken.mockReset()
-})
+	mockGetToken.mockReset();
+});
 
 // ---------------------------------------------------------------------------
 // Tests — happy path (inside AuthProvider)
@@ -114,28 +122,28 @@ beforeEach(() => {
 
 describe("useAuth — inside AuthProvider", () => {
 	it("returns the AuthContext value when called inside AuthProvider", async () => {
-		mockGetToken.mockReturnValue("test-token")
+		mockGetToken.mockReturnValue("test-token");
 
-		const div = await mountWithProvider()
-		const span = div.querySelector("span")
+		const div = await mountWithProvider();
+		const span = div.querySelector("span");
 
-		expect(span).not.toBeNull()
-		expect(span?.dataset.token).toBe("test-token")
-		expect(span?.dataset.isAuthenticated).toBe("true")
-		expect(span?.dataset.hasLogin).toBe("true")
-		expect(span?.dataset.hasLogout).toBe("true")
-	})
+		expect(span).not.toBeNull();
+		expect(span?.dataset.token).toBe("test-token");
+		expect(span?.dataset.isAuthenticated).toBe("true");
+		expect(span?.dataset.hasLogin).toBe("true");
+		expect(span?.dataset.hasLogout).toBe("true");
+	});
 
 	it("returns isAuthenticated false when token is null in AuthProvider", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		const div = await mountWithProvider()
-		const span = div.querySelector("span")
+		const div = await mountWithProvider();
+		const span = div.querySelector("span");
 
-		expect(span?.dataset.isAuthenticated).toBe("false")
-		expect(span?.dataset.token).toBe("null")
-	})
-})
+		expect(span?.dataset.isAuthenticated).toBe("false");
+		expect(span?.dataset.token).toBe("null");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — error path (outside AuthProvider)
@@ -145,37 +153,39 @@ describe("useAuth — outside AuthProvider", () => {
 	it("throws 'useAuth must be used within AuthProvider' when called without a provider", async () => {
 		// `thrown` is defined inside the test so BadComponent closes over it,
 		// which prevents unicorn/consistent-function-scoping from flagging it.
-		const thrown: { error: Error | undefined } = { error: undefined }
+		const thrown: { error: Error | undefined } = { error: undefined };
 
 		function BadComponent(): React.ReactElement {
 			try {
 				// biome-ignore lint/correctness/useHookAtTopLevel: intentionally testing hook called without a provider
-				useAuth()
+				useAuth();
 			} catch (error) {
 				if (error instanceof Error) {
-					thrown.error = error
+					thrown.error = error;
 				}
 			}
-			return React.createElement("span", null, "bad")
+			return React.createElement("span", null, "bad");
 		}
 
 		// Suppress React's error-boundary console.error noise during this test
 		// biome-ignore lint/suspicious/noConsole: silencing React render errors in tests
-		const originalConsoleError = console.error
-		console.error = vi.fn()
+		const originalConsoleError = console.error;
+		console.error = vi.fn();
 
-		const div = document.createElement("div")
-		document.body.append(div)
-		container = div
+		const div = document.createElement("div");
+		document.body.append(div);
+		container = div;
 
 		await act(async () => {
-			root = createRoot(div)
-			root.render(React.createElement(BadComponent))
-		})
+			root = createRoot(div);
+			root.render(React.createElement(BadComponent));
+		});
 
-		console.error = originalConsoleError
+		console.error = originalConsoleError;
 
-		expect(thrown.error).toBeInstanceOf(Error)
-		expect(thrown.error?.message).toBe("useAuth must be used within AuthProvider")
-	})
-})
+		expect(thrown.error).toBeInstanceOf(Error);
+		expect(thrown.error?.message).toBe(
+			"useAuth must be used within AuthProvider",
+		);
+	});
+});

--- a/apps/react-frontend/src/features/auth/hooks/useAuth.ts
+++ b/apps/react-frontend/src/features/auth/hooks/useAuth.ts
@@ -1,13 +1,13 @@
-import { useContext } from "react"
+import { useContext } from "react";
 import {
 	AuthContext,
 	type AuthContextValue,
-} from "@/features/auth/contexts/AuthContext"
+} from "@/features/auth/contexts/AuthContext";
 
 export function useAuth(): AuthContextValue {
-	const context = useContext(AuthContext)
+	const context = useContext(AuthContext);
 	if (context === null) {
-		throw new Error("useAuth must be used within AuthProvider")
+		throw new Error("useAuth must be used within AuthProvider");
 	}
-	return context
+	return context;
 }

--- a/apps/react-frontend/src/features/auth/hooks/useLoginForm.ts
+++ b/apps/react-frontend/src/features/auth/hooks/useLoginForm.ts
@@ -1,51 +1,51 @@
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useNavigate } from '@tanstack/react-router'
-import { toast } from '@repo/ui'
-import { useForm } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
-import { z } from 'zod'
-import { postV1UsersLogin } from '@/generated/sdk.gen'
-import { useAuth } from '@/features/auth/hooks/useAuth'
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "@repo/ui";
+import { useNavigate } from "@tanstack/react-router";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import { postV1UsersLogin } from "@/generated/sdk.gen";
 
 function useLoginFormSchema() {
-  const { t } = useTranslation()
-  return z.object({
-    email: z.email(t('login.validation.emailInvalid')),
-    password: z.string().min(1, t('login.validation.passwordRequired')),
-  })
+	const { t } = useTranslation();
+	return z.object({
+		email: z.email(t("login.validation.emailInvalid")),
+		password: z.string().min(1, t("login.validation.passwordRequired")),
+	});
 }
 
-type LoginFormValues = z.infer<ReturnType<typeof useLoginFormSchema>>
+type LoginFormValues = z.infer<ReturnType<typeof useLoginFormSchema>>;
 
 export function useLoginForm() {
-  const { t } = useTranslation()
-  const navigate = useNavigate()
-  const schema = useLoginFormSchema()
-  const { login } = useAuth()
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const schema = useLoginFormSchema();
+	const { login } = useAuth();
 
-  const form = useForm<LoginFormValues>({
-    resolver: zodResolver(schema),
-    defaultValues: { email: '', password: '' },
-  })
+	const form = useForm<LoginFormValues>({
+		resolver: zodResolver(schema),
+		defaultValues: { email: "", password: "" },
+	});
 
-  async function onSubmit(values: LoginFormValues) {
-    try {
-      const { data, error, response } = await postV1UsersLogin({
-        body: { email: values.email, password: values.password },
-        baseUrl: import.meta.env.VITE_API_BASE_URL,
-      })
-      if (error || !data) throw new Error(String(response.status))
-      login(data.token)
-      navigate({ to: '/' })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : ''
-      toast.error(
-        message === '401'
-          ? t('login.error.invalidCredentials')
-          : t('login.error.generic'),
-      )
-    }
-  }
+	async function onSubmit(values: LoginFormValues) {
+		try {
+			const { data, error, response } = await postV1UsersLogin({
+				body: { email: values.email, password: values.password },
+				baseUrl: import.meta.env.VITE_API_BASE_URL,
+			});
+			if (error || !data) throw new Error(String(response.status));
+			login(data.token);
+			navigate({ to: "/" });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "";
+			toast.error(
+				message === "401"
+					? t("login.error.invalidCredentials")
+					: t("login.error.generic"),
+			);
+		}
+	}
 
-  return { form, onSubmit }
+	return { form, onSubmit };
 }

--- a/apps/react-frontend/src/features/auth/hooks/useSignupForm.ts
+++ b/apps/react-frontend/src/features/auth/hooks/useSignupForm.ts
@@ -1,51 +1,55 @@
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useNavigate } from '@tanstack/react-router'
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
-import { z } from 'zod'
-import { postV1UsersSignup } from '@/generated/sdk.gen'
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+import { postV1UsersSignup } from "@/generated/sdk.gen";
 
 function useSignupFormSchema() {
-  const { t } = useTranslation()
-  return z.object({
-    name: z.string().min(1, t('signup.validation.nameRequired')),
-    email: z.email(t('signup.validation.emailInvalid')),
-    password: z.string().min(1, t('signup.validation.passwordRequired')),
-  })
+	const { t } = useTranslation();
+	return z.object({
+		name: z.string().min(1, t("signup.validation.nameRequired")),
+		email: z.email(t("signup.validation.emailInvalid")),
+		password: z.string().min(1, t("signup.validation.passwordRequired")),
+	});
 }
 
-type SignupFormValues = z.infer<ReturnType<typeof useSignupFormSchema>>
+type SignupFormValues = z.infer<ReturnType<typeof useSignupFormSchema>>;
 
 export function useSignupForm() {
-  const { t } = useTranslation()
-  const navigate = useNavigate()
-  const schema = useSignupFormSchema()
-  const [errorMessage, setErrorMessage] = useState<string>('')
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const schema = useSignupFormSchema();
+	const [errorMessage, setErrorMessage] = useState<string>("");
 
-  const form = useForm<SignupFormValues>({
-    resolver: zodResolver(schema),
-    defaultValues: { name: '', email: '', password: '' },
-  })
+	const form = useForm<SignupFormValues>({
+		resolver: zodResolver(schema),
+		defaultValues: { name: "", email: "", password: "" },
+	});
 
-  async function onSubmit(values: SignupFormValues) {
-    setErrorMessage('')
-    try {
-      const { data, error, response } = await postV1UsersSignup({
-        body: { name: values.name, email: values.email, password: values.password },
-        baseUrl: import.meta.env.VITE_API_BASE_URL,
-      })
-      if (error || !data) throw new Error(String(response.status))
-      navigate({ to: '/login' })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : ''
-      setErrorMessage(
-        message === '409'
-          ? t('signup.error.emailAlreadyRegistered')
-          : t('signup.error.generic'),
-      )
-    }
-  }
+	async function onSubmit(values: SignupFormValues) {
+		setErrorMessage("");
+		try {
+			const { data, error, response } = await postV1UsersSignup({
+				body: {
+					name: values.name,
+					email: values.email,
+					password: values.password,
+				},
+				baseUrl: import.meta.env.VITE_API_BASE_URL,
+			});
+			if (error || !data) throw new Error(String(response.status));
+			navigate({ to: "/login" });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "";
+			setErrorMessage(
+				message === "409"
+					? t("signup.error.emailAlreadyRegistered")
+					: t("signup.error.generic"),
+			);
+		}
+	}
 
-  return { form, onSubmit, errorMessage }
+	return { form, onSubmit, errorMessage };
 }

--- a/apps/react-frontend/src/features/auth/pages/LoginPage.test.tsx
+++ b/apps/react-frontend/src/features/auth/pages/LoginPage.test.tsx
@@ -10,9 +10,9 @@
  *  - @repo/ui                          toast vi.mock
  */
 
-import React, { act } from "react"
-import { createRoot } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock functions (must be defined before vi.mock calls)
@@ -22,7 +22,7 @@ const { mockNavigate, mockToastError, mockLogin } = vi.hoisted(() => ({
 	mockNavigate: vi.fn(),
 	mockToastError: vi.fn(),
 	mockLogin: vi.fn(),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -30,13 +30,13 @@ const { mockNavigate, mockToastError, mockLogin } = vi.hoisted(() => ({
 
 vi.mock("@/generated/sdk.gen", () => ({
 	postV1UsersLogin: vi.fn(),
-}))
+}));
 
 vi.mock("@/utils/tokenStorage", () => ({
 	saveToken: vi.fn(),
 	getToken: vi.fn().mockReturnValue(null),
 	removeToken: vi.fn(),
-}))
+}));
 
 vi.mock("@/features/auth/hooks/useAuth", () => ({
 	useAuth: () => ({
@@ -45,58 +45,60 @@ vi.mock("@/features/auth/hooks/useAuth", () => ({
 		login: mockLogin,
 		logout: vi.fn(),
 	}),
-}))
+}));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => mockNavigate,
 	Link: ({ children, to }: { children: React.ReactNode; to: string }) =>
 		React.createElement("a", { href: to }, children),
-}))
+}));
 
 vi.mock("@repo/ui", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("@repo/ui")>()
+	const actual = await importOriginal<typeof import("@repo/ui")>();
 	return {
 		...actual,
 		toast: {
 			...actual.toast,
 			error: mockToastError,
 		},
-	}
-})
+	};
+});
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { postV1UsersLogin } from "@/generated/sdk.gen"
-import { LoginPage } from "./LoginPage"
+import { postV1UsersLogin } from "@/generated/sdk.gen";
+import { LoginPage } from "./LoginPage";
 
 // ---------------------------------------------------------------------------
 // Typed mock references
 // ---------------------------------------------------------------------------
 
-const mockPostV1UsersLogin = postV1UsersLogin as ReturnType<typeof vi.fn>
+const mockPostV1UsersLogin = postV1UsersLogin as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function mountLoginPage(): HTMLDivElement {
-	const container = document.createElement("div")
-	document.body.append(container)
+	const container = document.createElement("div");
+	document.body.append(container);
 	act(() => {
-		createRoot(container).render(<LoginPage />)
-	})
-	return container
+		createRoot(container).render(<LoginPage />);
+	});
+	return container;
 }
 
 async function submitForm(form: HTMLFormElement): Promise<void> {
 	await act(async () => {
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		// Allow react-hook-form's async validation to resolve
-		await Promise.resolve()
-		await Promise.resolve()
-	})
+		await Promise.resolve();
+		await Promise.resolve();
+	});
 }
 
 function fillInput(input: HTMLInputElement, value: string): void {
@@ -104,16 +106,16 @@ function fillInput(input: HTMLInputElement, value: string): void {
 		const nativeValueSetter = Object.getOwnPropertyDescriptor(
 			HTMLInputElement.prototype,
 			"value",
-		)?.set
-		nativeValueSetter?.call(input, value)
-		input.dispatchEvent(new Event("input", { bubbles: true }))
-		input.dispatchEvent(new Event("change", { bubbles: true }))
-	})
+		)?.set;
+		nativeValueSetter?.call(input, value);
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		input.dispatchEvent(new Event("change", { bubbles: true }));
+	});
 }
 
 function clearBody(): void {
 	while (document.body.firstChild) {
-		document.body.firstChild.remove()
+		document.body.firstChild.remove();
 	}
 }
 
@@ -122,17 +124,17 @@ function clearBody(): void {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	vi.stubEnv("VITE_API_BASE_URL", "http://localhost:8080")
-	mockPostV1UsersLogin.mockReset()
-	mockLogin.mockReset()
-	mockNavigate.mockReset()
-	mockToastError.mockReset()
-})
+	vi.stubEnv("VITE_API_BASE_URL", "http://localhost:8080");
+	mockPostV1UsersLogin.mockReset();
+	mockLogin.mockReset();
+	mockNavigate.mockReset();
+	mockToastError.mockReset();
+});
 
 afterEach(() => {
-	clearBody()
-	vi.unstubAllEnvs()
-})
+	clearBody();
+	vi.unstubAllEnvs();
+});
 
 // ---------------------------------------------------------------------------
 // Tests — rendering
@@ -140,29 +142,29 @@ afterEach(() => {
 
 describe("LoginPage — rendering", () => {
 	it("renders an email input", () => {
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
-		expect(emailInput).not.toBeNull()
-	})
+		);
+		expect(emailInput).not.toBeNull();
+	});
 
 	it("renders a password input with type='password'", () => {
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		expect(passwordInput).not.toBeNull()
-	})
+		);
+		expect(passwordInput).not.toBeNull();
+	});
 
 	it("renders a submit button", () => {
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn).not.toBeNull()
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn).not.toBeNull();
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — client-side validation
@@ -170,38 +172,38 @@ describe("LoginPage — rendering", () => {
 
 describe("LoginPage — client-side validation", () => {
 	it("shows 'Invalid email address' when email is empty on submit", async () => {
-		const container = mountLoginPage()
-		const form = container.querySelector<HTMLFormElement>("form")
-		expect(form).not.toBeNull()
+		const container = mountLoginPage();
+		const form = container.querySelector<HTMLFormElement>("form");
+		expect(form).not.toBeNull();
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
-		expect(container.textContent).toContain("Invalid email address")
-	})
+		expect(container.textContent).toContain("Invalid email address");
+	});
 
 	it("shows 'Password is required' when password is empty on submit", async () => {
-		const container = mountLoginPage()
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountLoginPage();
+		const form = container.querySelector<HTMLFormElement>("form");
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
-		expect(form).not.toBeNull()
-		expect(emailInput).not.toBeNull()
+		);
+		expect(form).not.toBeNull();
+		expect(emailInput).not.toBeNull();
 
-		fillInput(emailInput as HTMLInputElement, "user@example.com")
-		await submitForm(form as HTMLFormElement)
+		fillInput(emailInput as HTMLInputElement, "user@example.com");
+		await submitForm(form as HTMLFormElement);
 
-		expect(container.textContent).toContain("Password is required")
-	})
+		expect(container.textContent).toContain("Password is required");
+	});
 
 	it("does not call postV1UsersLogin when validation fails", async () => {
-		const container = mountLoginPage()
-		const form = container.querySelector<HTMLFormElement>("form")
-		await submitForm(form as HTMLFormElement)
+		const container = mountLoginPage();
+		const form = container.querySelector<HTMLFormElement>("form");
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockPostV1UsersLogin).not.toHaveBeenCalled()
-	})
-})
+		expect(mockPostV1UsersLogin).not.toHaveBeenCalled();
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — loading state
@@ -209,29 +211,27 @@ describe("LoginPage — client-side validation", () => {
 
 describe("LoginPage — loading state", () => {
 	it("disables the submit button while the API call is in-flight", async () => {
-		mockPostV1UsersLogin.mockImplementation(
-			() => new Promise<never>(() => {}),
-		)
+		mockPostV1UsersLogin.mockImplementation(() => new Promise<never>(() => {}));
 
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(emailInput as HTMLInputElement, "user@example.com")
-		fillInput(passwordInput as HTMLInputElement, "password123")
-		await submitForm(form as HTMLFormElement)
+		fillInput(emailInput as HTMLInputElement, "user@example.com");
+		fillInput(passwordInput as HTMLInputElement, "password123");
+		await submitForm(form as HTMLFormElement);
 
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn?.disabled).toBe(true)
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn?.disabled).toBe(true);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — successful login
@@ -242,56 +242,56 @@ describe("LoginPage — successful login", () => {
 		token: "jwt-abc-123",
 		expiresAt: "2026-12-31T00:00:00Z",
 		user: { id: "u1", name: "Alice", email: "alice@example.com" },
-	}
+	};
 
 	it("calls login with the token returned by the API", async () => {
 		mockPostV1UsersLogin.mockResolvedValue({
 			data: VALID_RESPONSE,
 			error: undefined,
 			response: { status: 200 },
-		})
+		});
 
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(emailInput as HTMLInputElement, "alice@example.com")
-		fillInput(passwordInput as HTMLInputElement, "secret")
+		fillInput(emailInput as HTMLInputElement, "alice@example.com");
+		fillInput(passwordInput as HTMLInputElement, "secret");
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockLogin).toHaveBeenCalledWith("jwt-abc-123")
-	})
+		expect(mockLogin).toHaveBeenCalledWith("jwt-abc-123");
+	});
 
 	it("navigates to '/' after a successful login", async () => {
 		mockPostV1UsersLogin.mockResolvedValue({
 			data: VALID_RESPONSE,
 			error: undefined,
 			response: { status: 200 },
-		})
+		});
 
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(emailInput as HTMLInputElement, "alice@example.com")
-		fillInput(passwordInput as HTMLInputElement, "secret")
+		fillInput(emailInput as HTMLInputElement, "alice@example.com");
+		fillInput(passwordInput as HTMLInputElement, "secret");
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockNavigate).toHaveBeenCalledWith({ to: "/" })
-	})
-})
+		expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — failed login
@@ -314,78 +314,78 @@ describe("LoginPage — failed login", () => {
 			mock: { data: undefined, error: {}, response: { status: 403 } },
 			expectedMessage: "Login failed. Please try again.",
 		},
-	]
+	];
 
 	for (const { name, mock, expectedMessage } of errorCases) {
 		it(name, async () => {
-			mockPostV1UsersLogin.mockResolvedValue(mock)
+			mockPostV1UsersLogin.mockResolvedValue(mock);
 
-			const container = mountLoginPage()
+			const container = mountLoginPage();
 			const emailInput = container.querySelector<HTMLInputElement>(
 				'input[type="email"], input[name="email"]',
-			)
+			);
 			const passwordInput = container.querySelector<HTMLInputElement>(
 				'input[type="password"]',
-			)
-			const form = container.querySelector<HTMLFormElement>("form")
+			);
+			const form = container.querySelector<HTMLFormElement>("form");
 
-			fillInput(emailInput as HTMLInputElement, "user@example.com")
-			fillInput(passwordInput as HTMLInputElement, "password123")
+			fillInput(emailInput as HTMLInputElement, "user@example.com");
+			fillInput(passwordInput as HTMLInputElement, "password123");
 
-			await submitForm(form as HTMLFormElement)
+			await submitForm(form as HTMLFormElement);
 
 			expect(mockToastError).toHaveBeenCalledWith(
 				expect.stringContaining(expectedMessage),
-			)
-		})
+			);
+		});
 	}
 
 	it("shows generic error toast on a network-level failure", async () => {
-		mockPostV1UsersLogin.mockRejectedValue(new Error("Network failure"))
+		mockPostV1UsersLogin.mockRejectedValue(new Error("Network failure"));
 
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(emailInput as HTMLInputElement, "user@example.com")
-		fillInput(passwordInput as HTMLInputElement, "password123")
+		fillInput(emailInput as HTMLInputElement, "user@example.com");
+		fillInput(passwordInput as HTMLInputElement, "password123");
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
 		expect(mockToastError).toHaveBeenCalledWith(
 			expect.stringContaining("Login failed. Please try again."),
-		)
-	})
+		);
+	});
 
 	it("re-enables the submit button after a failed login", async () => {
 		mockPostV1UsersLogin.mockResolvedValue({
 			data: undefined,
 			error: {},
 			response: { status: 500 },
-		})
+		});
 
-		const container = mountLoginPage()
+		const container = mountLoginPage();
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(emailInput as HTMLInputElement, "user@example.com")
-		fillInput(passwordInput as HTMLInputElement, "password123")
+		fillInput(emailInput as HTMLInputElement, "user@example.com");
+		fillInput(passwordInput as HTMLInputElement, "password123");
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn?.disabled).toBe(false)
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn?.disabled).toBe(false);
+	});
+});

--- a/apps/react-frontend/src/features/auth/pages/LoginPage.tsx
+++ b/apps/react-frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,85 +1,85 @@
 import {
-  Button,
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-  Heading,
-  Input,
-} from '@repo/ui'
-import { Link } from '@tanstack/react-router'
-import { useTranslation } from 'react-i18next'
-import { useLoginForm } from '@/features/auth/hooks/useLoginForm'
+	Button,
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+	Heading,
+	Input,
+} from "@repo/ui";
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { useLoginForm } from "@/features/auth/hooks/useLoginForm";
 
 export function LoginPage() {
-  const { t } = useTranslation()
-  const { form, onSubmit } = useLoginForm()
+	const { t } = useTranslation();
+	const { form, onSubmit } = useLoginForm();
 
-  return (
-    <main className="page-wrap flex min-h-[60vh] items-center justify-center px-4 py-12">
-      <section className="island-shell w-full max-w-sm rounded-2xl p-6 sm:p-8">
-        <Heading level={1}>{t('login.title')}</Heading>
+	return (
+		<main className="page-wrap flex min-h-[60vh] items-center justify-center px-4 py-12">
+			<section className="island-shell w-full max-w-sm rounded-2xl p-6 sm:p-8">
+				<Heading level={1}>{t("login.title")}</Heading>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
-            <div className="mb-4">
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('login.email.label')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        placeholder={t('login.email.placeholder')}
-                        autoComplete="email"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+				<Form {...form}>
+					<form onSubmit={form.handleSubmit(onSubmit)} noValidate>
+						<div className="mb-4">
+							<FormField
+								control={form.control}
+								name="email"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>{t("login.email.label")}</FormLabel>
+										<FormControl>
+											<Input
+												type="email"
+												placeholder={t("login.email.placeholder")}
+												autoComplete="email"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 
-            <div className="mb-6">
-              <FormField
-                control={form.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('login.password.label')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        placeholder={t('login.password.placeholder')}
-                        autoComplete="current-password"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+						<div className="mb-6">
+							<FormField
+								control={form.control}
+								name="password"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>{t("login.password.label")}</FormLabel>
+										<FormControl>
+											<Input
+												type="password"
+												placeholder={t("login.password.placeholder")}
+												autoComplete="current-password"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 
-            <div className="w-full">
-              <Button type="submit" disabled={form.formState.isSubmitting}>
-                {form.formState.isSubmitting
-                  ? t('login.submitting')
-                  : t('login.submit')}
-              </Button>
-            </div>
-          </form>
-        </Form>
+						<div className="w-full">
+							<Button type="submit" disabled={form.formState.isSubmitting}>
+								{form.formState.isSubmitting
+									? t("login.submitting")
+									: t("login.submit")}
+							</Button>
+						</div>
+					</form>
+				</Form>
 
-        <p className="mt-4 text-center text-sm">
-          <Link to="/signup">{t('login.signupLink')}</Link>
-        </p>
-      </section>
-    </main>
-  )
+				<p className="mt-4 text-center text-sm">
+					<Link to="/signup">{t("login.signupLink")}</Link>
+				</p>
+			</section>
+		</main>
+	);
 }

--- a/apps/react-frontend/src/features/auth/pages/SignupPage.test.tsx
+++ b/apps/react-frontend/src/features/auth/pages/SignupPage.test.tsx
@@ -10,9 +10,9 @@
  * Note: errors are shown inline in the page (NOT via toast).
  */
 
-import { act } from "react"
-import { createRoot } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock functions (must be defined before vi.mock calls)
@@ -20,7 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const { mockNavigate } = vi.hoisted(() => ({
 	mockNavigate: vi.fn(),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -28,45 +28,47 @@ const { mockNavigate } = vi.hoisted(() => ({
 
 vi.mock("@/generated/sdk.gen", () => ({
 	postV1UsersSignup: vi.fn(),
-}))
+}));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => mockNavigate,
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { postV1UsersSignup } from "@/generated/sdk.gen"
-import { SignupPage } from "./SignupPage"
+import { postV1UsersSignup } from "@/generated/sdk.gen";
+import { SignupPage } from "./SignupPage";
 
 // ---------------------------------------------------------------------------
 // Typed mock references
 // ---------------------------------------------------------------------------
 
-const mockPostV1UsersSignup = postV1UsersSignup as ReturnType<typeof vi.fn>
+const mockPostV1UsersSignup = postV1UsersSignup as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function mountSignupPage(): HTMLDivElement {
-	const container = document.createElement("div")
-	document.body.append(container)
+	const container = document.createElement("div");
+	document.body.append(container);
 	act(() => {
-		createRoot(container).render(<SignupPage />)
-	})
-	return container
+		createRoot(container).render(<SignupPage />);
+	});
+	return container;
 }
 
 async function submitForm(form: HTMLFormElement): Promise<void> {
 	await act(async () => {
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		// Allow react-hook-form's async validation to resolve
-		await Promise.resolve()
-		await Promise.resolve()
-	})
+		await Promise.resolve();
+		await Promise.resolve();
+	});
 }
 
 function fillInput(input: HTMLInputElement, value: string): void {
@@ -74,16 +76,16 @@ function fillInput(input: HTMLInputElement, value: string): void {
 		const nativeValueSetter = Object.getOwnPropertyDescriptor(
 			HTMLInputElement.prototype,
 			"value",
-		)?.set
-		nativeValueSetter?.call(input, value)
-		input.dispatchEvent(new Event("input", { bubbles: true }))
-		input.dispatchEvent(new Event("change", { bubbles: true }))
-	})
+		)?.set;
+		nativeValueSetter?.call(input, value);
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		input.dispatchEvent(new Event("change", { bubbles: true }));
+	});
 }
 
 function clearBody(): void {
 	while (document.body.firstChild) {
-		document.body.firstChild.remove()
+		document.body.firstChild.remove();
 	}
 }
 
@@ -92,15 +94,15 @@ function clearBody(): void {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	vi.stubEnv("VITE_API_BASE_URL", "http://localhost:8080")
-	mockPostV1UsersSignup.mockReset()
-	mockNavigate.mockReset()
-})
+	vi.stubEnv("VITE_API_BASE_URL", "http://localhost:8080");
+	mockPostV1UsersSignup.mockReset();
+	mockNavigate.mockReset();
+});
 
 afterEach(() => {
-	clearBody()
-	vi.unstubAllEnvs()
-})
+	clearBody();
+	vi.unstubAllEnvs();
+});
 
 // ---------------------------------------------------------------------------
 // Tests — rendering
@@ -108,37 +110,37 @@ afterEach(() => {
 
 describe("SignupPage — rendering", () => {
 	it("renders a name input", () => {
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const nameInput = container.querySelector<HTMLInputElement>(
 			'input[name="name"], input[placeholder*="name" i]',
-		)
-		expect(nameInput).not.toBeNull()
-	})
+		);
+		expect(nameInput).not.toBeNull();
+	});
 
 	it("renders an email input", () => {
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
-		expect(emailInput).not.toBeNull()
-	})
+		);
+		expect(emailInput).not.toBeNull();
+	});
 
 	it("renders a password input with type='password'", () => {
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		expect(passwordInput).not.toBeNull()
-	})
+		);
+		expect(passwordInput).not.toBeNull();
+	});
 
 	it("renders a submit button", () => {
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn).not.toBeNull()
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn).not.toBeNull();
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — client-side validation
@@ -146,58 +148,58 @@ describe("SignupPage — rendering", () => {
 
 describe("SignupPage — client-side validation", () => {
 	it("shows 'Name is required' when name is empty on submit", async () => {
-		const container = mountSignupPage()
-		const form = container.querySelector<HTMLFormElement>("form")
-		expect(form).not.toBeNull()
+		const container = mountSignupPage();
+		const form = container.querySelector<HTMLFormElement>("form");
+		expect(form).not.toBeNull();
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
-		expect(container.textContent).toContain("Name is required")
-	})
+		expect(container.textContent).toContain("Name is required");
+	});
 
 	it("shows 'Invalid email address' when email is empty on submit", async () => {
-		const container = mountSignupPage()
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountSignupPage();
+		const form = container.querySelector<HTMLFormElement>("form");
 		const nameInput = container.querySelector<HTMLInputElement>(
 			'input[name="name"], input[placeholder*="name" i]',
-		)
-		expect(form).not.toBeNull()
-		expect(nameInput).not.toBeNull()
+		);
+		expect(form).not.toBeNull();
+		expect(nameInput).not.toBeNull();
 
-		fillInput(nameInput as HTMLInputElement, "Alice")
-		await submitForm(form as HTMLFormElement)
+		fillInput(nameInput as HTMLInputElement, "Alice");
+		await submitForm(form as HTMLFormElement);
 
-		expect(container.textContent).toContain("Invalid email address")
-	})
+		expect(container.textContent).toContain("Invalid email address");
+	});
 
 	it("shows 'Password is required' when password is empty on submit", async () => {
-		const container = mountSignupPage()
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountSignupPage();
+		const form = container.querySelector<HTMLFormElement>("form");
 		const nameInput = container.querySelector<HTMLInputElement>(
 			'input[name="name"], input[placeholder*="name" i]',
-		)
+		);
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
-		expect(form).not.toBeNull()
-		expect(nameInput).not.toBeNull()
-		expect(emailInput).not.toBeNull()
+		);
+		expect(form).not.toBeNull();
+		expect(nameInput).not.toBeNull();
+		expect(emailInput).not.toBeNull();
 
-		fillInput(nameInput as HTMLInputElement, "Alice")
-		fillInput(emailInput as HTMLInputElement, "alice@example.com")
-		await submitForm(form as HTMLFormElement)
+		fillInput(nameInput as HTMLInputElement, "Alice");
+		fillInput(emailInput as HTMLInputElement, "alice@example.com");
+		await submitForm(form as HTMLFormElement);
 
-		expect(container.textContent).toContain("Password is required")
-	})
+		expect(container.textContent).toContain("Password is required");
+	});
 
 	it("does not call postV1UsersSignup when validation fails", async () => {
-		const container = mountSignupPage()
-		const form = container.querySelector<HTMLFormElement>("form")
-		await submitForm(form as HTMLFormElement)
+		const container = mountSignupPage();
+		const form = container.querySelector<HTMLFormElement>("form");
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockPostV1UsersSignup).not.toHaveBeenCalled()
-	})
-})
+		expect(mockPostV1UsersSignup).not.toHaveBeenCalled();
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — loading state
@@ -207,31 +209,31 @@ describe("SignupPage — loading state", () => {
 	it("disables the submit button while the API call is in-flight", async () => {
 		mockPostV1UsersSignup.mockImplementation(
 			() => new Promise<never>(() => {}),
-		)
+		);
 
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const nameInput = container.querySelector<HTMLInputElement>(
 			'input[name="name"], input[placeholder*="name" i]',
-		)
+		);
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(nameInput as HTMLInputElement, "Alice")
-		fillInput(emailInput as HTMLInputElement, "alice@example.com")
-		fillInput(passwordInput as HTMLInputElement, "password123")
-		await submitForm(form as HTMLFormElement)
+		fillInput(nameInput as HTMLInputElement, "Alice");
+		fillInput(emailInput as HTMLInputElement, "alice@example.com");
+		fillInput(passwordInput as HTMLInputElement, "password123");
+		await submitForm(form as HTMLFormElement);
 
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn?.disabled).toBe(true)
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn?.disabled).toBe(true);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — successful signup
@@ -240,32 +242,38 @@ describe("SignupPage — loading state", () => {
 describe("SignupPage — successful signup", () => {
 	it("navigates to '/login' after a successful signup", async () => {
 		mockPostV1UsersSignup.mockResolvedValue({
-			data: { id: "u1", name: "Alice", email: "alice@example.com", status: "active", createdAt: "2026-03-15T00:00:00Z" },
+			data: {
+				id: "u1",
+				name: "Alice",
+				email: "alice@example.com",
+				status: "active",
+				createdAt: "2026-03-15T00:00:00Z",
+			},
 			error: undefined,
 			response: { status: 201 },
-		})
+		});
 
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const nameInput = container.querySelector<HTMLInputElement>(
 			'input[name="name"], input[placeholder*="name" i]',
-		)
+		);
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(nameInput as HTMLInputElement, "Alice")
-		fillInput(emailInput as HTMLInputElement, "alice@example.com")
-		fillInput(passwordInput as HTMLInputElement, "password123")
+		fillInput(nameInput as HTMLInputElement, "Alice");
+		fillInput(emailInput as HTMLInputElement, "alice@example.com");
+		fillInput(passwordInput as HTMLInputElement, "password123");
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" })
-	})
-})
+		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" });
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — failed signup (inline errors, NOT toast)
@@ -283,87 +291,87 @@ describe("SignupPage — failed signup", () => {
 			mock: { data: undefined, error: {}, response: { status: 500 } },
 			expectedMessage: "Signup failed",
 		},
-	]
+	];
 
 	for (const { name, mock, expectedMessage } of errorCases) {
 		it(name, async () => {
-			mockPostV1UsersSignup.mockResolvedValue(mock)
+			mockPostV1UsersSignup.mockResolvedValue(mock);
 
-			const container = mountSignupPage()
+			const container = mountSignupPage();
 			const nameInput = container.querySelector<HTMLInputElement>(
 				'input[name="name"], input[placeholder*="name" i]',
-			)
+			);
 			const emailInput = container.querySelector<HTMLInputElement>(
 				'input[type="email"], input[name="email"]',
-			)
+			);
 			const passwordInput = container.querySelector<HTMLInputElement>(
 				'input[type="password"]',
-			)
-			const form = container.querySelector<HTMLFormElement>("form")
+			);
+			const form = container.querySelector<HTMLFormElement>("form");
 
-			fillInput(nameInput as HTMLInputElement, "Alice")
-			fillInput(emailInput as HTMLInputElement, "alice@example.com")
-			fillInput(passwordInput as HTMLInputElement, "password123")
+			fillInput(nameInput as HTMLInputElement, "Alice");
+			fillInput(emailInput as HTMLInputElement, "alice@example.com");
+			fillInput(passwordInput as HTMLInputElement, "password123");
 
-			await submitForm(form as HTMLFormElement)
+			await submitForm(form as HTMLFormElement);
 
 			// Error must be visible inline in the page, not in a toast
-			expect(container.textContent).toContain(expectedMessage)
-		})
+			expect(container.textContent).toContain(expectedMessage);
+		});
 	}
 
 	it("shows generic inline error on a network-level failure", async () => {
-		mockPostV1UsersSignup.mockRejectedValue(new Error("Network failure"))
+		mockPostV1UsersSignup.mockRejectedValue(new Error("Network failure"));
 
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const nameInput = container.querySelector<HTMLInputElement>(
 			'input[name="name"], input[placeholder*="name" i]',
-		)
+		);
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(nameInput as HTMLInputElement, "Alice")
-		fillInput(emailInput as HTMLInputElement, "alice@example.com")
-		fillInput(passwordInput as HTMLInputElement, "password123")
+		fillInput(nameInput as HTMLInputElement, "Alice");
+		fillInput(emailInput as HTMLInputElement, "alice@example.com");
+		fillInput(passwordInput as HTMLInputElement, "password123");
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
-		expect(container.textContent).toContain("Signup failed")
-	})
+		expect(container.textContent).toContain("Signup failed");
+	});
 
 	it("re-enables the submit button after a failed signup", async () => {
 		mockPostV1UsersSignup.mockResolvedValue({
 			data: undefined,
 			error: {},
 			response: { status: 500 },
-		})
+		});
 
-		const container = mountSignupPage()
+		const container = mountSignupPage();
 		const nameInput = container.querySelector<HTMLInputElement>(
 			'input[name="name"], input[placeholder*="name" i]',
-		)
+		);
 		const emailInput = container.querySelector<HTMLInputElement>(
 			'input[type="email"], input[name="email"]',
-		)
+		);
 		const passwordInput = container.querySelector<HTMLInputElement>(
 			'input[type="password"]',
-		)
-		const form = container.querySelector<HTMLFormElement>("form")
+		);
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillInput(nameInput as HTMLInputElement, "Alice")
-		fillInput(emailInput as HTMLInputElement, "alice@example.com")
-		fillInput(passwordInput as HTMLInputElement, "password123")
+		fillInput(nameInput as HTMLInputElement, "Alice");
+		fillInput(emailInput as HTMLInputElement, "alice@example.com");
+		fillInput(passwordInput as HTMLInputElement, "password123");
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn?.disabled).toBe(false)
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn?.disabled).toBe(false);
+	});
+});

--- a/apps/react-frontend/src/features/auth/pages/SignupPage.tsx
+++ b/apps/react-frontend/src/features/auth/pages/SignupPage.tsx
@@ -1,107 +1,107 @@
 import {
-  Button,
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-  Heading,
-  Input,
-} from '@repo/ui'
-import { useTranslation } from 'react-i18next'
-import { useSignupForm } from '@/features/auth/hooks/useSignupForm'
+	Button,
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+	Heading,
+	Input,
+} from "@repo/ui";
+import { useTranslation } from "react-i18next";
+import { useSignupForm } from "@/features/auth/hooks/useSignupForm";
 
 export function SignupPage() {
-  const { t } = useTranslation()
-  const { form, onSubmit, errorMessage } = useSignupForm()
+	const { t } = useTranslation();
+	const { form, onSubmit, errorMessage } = useSignupForm();
 
-  return (
-    <main className="page-wrap flex min-h-[60vh] items-center justify-center px-4 py-12">
-      <section className="island-shell w-full max-w-sm rounded-2xl p-6 sm:p-8">
-        <Heading level={1}>{t('signup.title')}</Heading>
+	return (
+		<main className="page-wrap flex min-h-[60vh] items-center justify-center px-4 py-12">
+			<section className="island-shell w-full max-w-sm rounded-2xl p-6 sm:p-8">
+				<Heading level={1}>{t("signup.title")}</Heading>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
-            <div className="mb-4">
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('signup.name.label')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="text"
-                        placeholder={t('signup.name.placeholder')}
-                        autoComplete="name"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+				<Form {...form}>
+					<form onSubmit={form.handleSubmit(onSubmit)} noValidate>
+						<div className="mb-4">
+							<FormField
+								control={form.control}
+								name="name"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>{t("signup.name.label")}</FormLabel>
+										<FormControl>
+											<Input
+												type="text"
+												placeholder={t("signup.name.placeholder")}
+												autoComplete="name"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 
-            <div className="mb-4">
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('signup.email.label')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        placeholder={t('signup.email.placeholder')}
-                        autoComplete="email"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+						<div className="mb-4">
+							<FormField
+								control={form.control}
+								name="email"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>{t("signup.email.label")}</FormLabel>
+										<FormControl>
+											<Input
+												type="email"
+												placeholder={t("signup.email.placeholder")}
+												autoComplete="email"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 
-            <div className="mb-6">
-              <FormField
-                control={form.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('signup.password.label')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        placeholder={t('signup.password.placeholder')}
-                        autoComplete="new-password"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+						<div className="mb-6">
+							<FormField
+								control={form.control}
+								name="password"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>{t("signup.password.label")}</FormLabel>
+										<FormControl>
+											<Input
+												type="password"
+												placeholder={t("signup.password.placeholder")}
+												autoComplete="new-password"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 
-            {errorMessage && (
-              <div className="mb-4">
-                <p className="text-sm text-red-600">{errorMessage}</p>
-              </div>
-            )}
+						{errorMessage && (
+							<div className="mb-4">
+								<p className="text-sm text-red-600">{errorMessage}</p>
+							</div>
+						)}
 
-            <div className="w-full">
-              <Button type="submit" disabled={form.formState.isSubmitting}>
-                {form.formState.isSubmitting
-                  ? t('signup.submitting')
-                  : t('signup.submit')}
-              </Button>
-            </div>
-          </form>
-        </Form>
-      </section>
-    </main>
-  )
+						<div className="w-full">
+							<Button type="submit" disabled={form.formState.isSubmitting}>
+								{form.formState.isSubmitting
+									? t("signup.submitting")
+									: t("signup.submit")}
+							</Button>
+						</div>
+					</form>
+				</Form>
+			</section>
+		</main>
+	);
 }

--- a/apps/react-frontend/src/features/auth/utils/tokenStorage.test.ts
+++ b/apps/react-frontend/src/features/auth/utils/tokenStorage.test.ts
@@ -1,15 +1,15 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest";
 import {
 	getToken,
 	removeToken,
 	saveToken,
-} from "@/features/auth/utils/tokenStorage"
+} from "@/features/auth/utils/tokenStorage";
 
 // ---------------------------------------------------------------------------
 // The localStorage key the module is expected to use.
 // Keeping it here makes the intent explicit and guards against typos.
 // ---------------------------------------------------------------------------
-const AUTH_TOKEN_KEY = "auth_token"
+const AUTH_TOKEN_KEY = "auth_token";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -19,96 +19,96 @@ describe("tokenStorage", () => {
 	// Always start each test with a clean slate so tests do not bleed into
 	// each other regardless of execution order.
 	afterEach(() => {
-		localStorage.clear()
-	})
+		localStorage.clear();
+	});
 
 	// -------------------------------------------------------------------------
 	// saveToken
 	// -------------------------------------------------------------------------
 	describe("saveToken", () => {
 		it("stores the token in localStorage under the key 'auth_token'", () => {
-			saveToken("my-jwt")
+			saveToken("my-jwt");
 
-			expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe("my-jwt")
-		})
+			expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe("my-jwt");
+		});
 
 		const overwriteCases = [
 			{ name: "short token", first: "first-token", second: "second-token" },
 			{ name: "empty string token", first: "some-token", second: "" },
-		]
+		];
 
 		for (const { name, first, second } of overwriteCases) {
 			it(`overwrites a previously saved token — ${name}`, () => {
-				saveToken(first)
-				saveToken(second)
+				saveToken(first);
+				saveToken(second);
 
-				expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe(second)
-			})
+				expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe(second);
+			});
 		}
-	})
+	});
 
 	// -------------------------------------------------------------------------
 	// getToken
 	// -------------------------------------------------------------------------
 	describe("getToken", () => {
 		it("returns the token that was previously saved", () => {
-			localStorage.setItem(AUTH_TOKEN_KEY, "stored-jwt")
+			localStorage.setItem(AUTH_TOKEN_KEY, "stored-jwt");
 
-			expect(getToken()).toBe("stored-jwt")
-		})
+			expect(getToken()).toBe("stored-jwt");
+		});
 
 		it("returns null when no token has been saved", () => {
 			// localStorage starts empty thanks to afterEach
-			expect(getToken()).toBeNull()
-		})
+			expect(getToken()).toBeNull();
+		});
 
 		it("returns null after the token has been removed", () => {
-			localStorage.setItem(AUTH_TOKEN_KEY, "to-be-removed")
-			localStorage.removeItem(AUTH_TOKEN_KEY)
+			localStorage.setItem(AUTH_TOKEN_KEY, "to-be-removed");
+			localStorage.removeItem(AUTH_TOKEN_KEY);
 
-			expect(getToken()).toBeNull()
-		})
-	})
+			expect(getToken()).toBeNull();
+		});
+	});
 
 	// -------------------------------------------------------------------------
 	// removeToken
 	// -------------------------------------------------------------------------
 	describe("removeToken", () => {
 		it("removes an existing token so getToken returns null afterwards", () => {
-			saveToken("jwt-to-delete")
+			saveToken("jwt-to-delete");
 
-			removeToken()
+			removeToken();
 
-			expect(getToken()).toBeNull()
-		})
+			expect(getToken()).toBeNull();
+		});
 
 		it("does not throw when called with no token present", () => {
 			// Expect removeToken to be a safe no-op when nothing is stored
-			expect(() => removeToken()).not.toThrow()
-		})
+			expect(() => removeToken()).not.toThrow();
+		});
 
 		it("does not affect other keys in localStorage", () => {
-			localStorage.setItem("other_key", "other_value")
-			saveToken("jwt-to-delete")
+			localStorage.setItem("other_key", "other_value");
+			saveToken("jwt-to-delete");
 
-			removeToken()
+			removeToken();
 
-			expect(localStorage.getItem("other_key")).toBe("other_value")
-		})
-	})
+			expect(localStorage.getItem("other_key")).toBe("other_value");
+		});
+	});
 
 	// -------------------------------------------------------------------------
 	// Round-trip: save → get → remove → get
 	// -------------------------------------------------------------------------
 	describe("full lifecycle round-trip", () => {
 		it("save then get returns the saved token, remove then get returns null", () => {
-			const token = "round-trip-token"
+			const token = "round-trip-token";
 
-			saveToken(token)
-			expect(getToken()).toBe(token)
+			saveToken(token);
+			expect(getToken()).toBe(token);
 
-			removeToken()
-			expect(getToken()).toBeNull()
-		})
-	})
-})
+			removeToken();
+			expect(getToken()).toBeNull();
+		});
+	});
+});

--- a/apps/react-frontend/src/features/auth/utils/tokenStorage.ts
+++ b/apps/react-frontend/src/features/auth/utils/tokenStorage.ts
@@ -1,13 +1,13 @@
-const AUTH_TOKEN_KEY = "auth_token"
+const AUTH_TOKEN_KEY = "auth_token";
 
 export function saveToken(token: string): void {
-	localStorage.setItem(AUTH_TOKEN_KEY, token)
+	localStorage.setItem(AUTH_TOKEN_KEY, token);
 }
 
 export function getToken(): string | null {
-	return localStorage.getItem(AUTH_TOKEN_KEY)
+	return localStorage.getItem(AUTH_TOKEN_KEY);
 }
 
 export function removeToken(): void {
-	localStorage.removeItem(AUTH_TOKEN_KEY)
+	localStorage.removeItem(AUTH_TOKEN_KEY);
 }

--- a/apps/react-frontend/src/features/home/pages/HomePage.test.tsx
+++ b/apps/react-frontend/src/features/home/pages/HomePage.test.tsx
@@ -7,10 +7,10 @@
  *  - @repo/ui   Card family components vi.mock (avoid style resolution issues)
  */
 
-import React, { act } from "react"
-import { createRoot } from "react-dom/client"
-import type { Root } from "react-dom/client"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import React, { act } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -27,29 +27,29 @@ vi.mock("@repo/ui", () => ({
 		React.createElement("p", { "data-testid": "card-description" }, children),
 	CardContent: ({ children }: { children: React.ReactNode }) =>
 		React.createElement("div", { "data-testid": "card-content" }, children),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { HomePage } from "./HomePage"
+import { HomePage } from "./HomePage";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-let root: Root | null = null
-let container: HTMLDivElement | null = null
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
 
 async function mount(): Promise<void> {
-	const div = document.createElement("div")
-	document.body.append(div)
-	container = div
+	const div = document.createElement("div");
+	document.body.append(div);
+	container = div;
 	await act(async () => {
-		root = createRoot(div)
-		root.render(<HomePage />)
-	})
+		root = createRoot(div);
+		root.render(<HomePage />);
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -58,15 +58,15 @@ async function mount(): Promise<void> {
 
 afterEach(async () => {
 	if (root) {
-		const r = root
-		root = null
+		const r = root;
+		root = null;
 		await act(async () => {
-			r.unmount()
-		})
+			r.unmount();
+		});
 	}
-	container?.remove()
-	container = null
-})
+	container?.remove();
+	container = null;
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -74,19 +74,21 @@ afterEach(async () => {
 
 describe("HomePage — rendering", () => {
 	it("renders the 'TODO: Home page' heading text", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='card-title']")?.textContent).toContain("TODO: Home page")
-	})
+		await mount();
+		expect(
+			document.querySelector("[data-testid='card-title']")?.textContent,
+		).toContain("TODO: Home page");
+	});
 
 	it("renders a card container", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='card']")).not.toBeNull()
-	})
+		await mount();
+		expect(document.querySelector("[data-testid='card']")).not.toBeNull();
+	});
 
 	it("renders the card description text", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='card-description']")?.textContent).toContain(
-			"Post-login home page content goes here."
-		)
-	})
-})
+		await mount();
+		expect(
+			document.querySelector("[data-testid='card-description']")?.textContent,
+		).toContain("Post-login home page content goes here.");
+	});
+});

--- a/apps/react-frontend/src/features/home/pages/HomePage.tsx
+++ b/apps/react-frontend/src/features/home/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import {
 	CardDescription,
 	CardHeader,
 	CardTitle,
-} from "@repo/ui"
+} from "@repo/ui";
 
 export function HomePage() {
 	return (
@@ -12,7 +12,9 @@ export function HomePage() {
 			<Card>
 				<CardHeader>
 					<CardTitle>TODO: Home page</CardTitle>
-					<CardDescription>Post-login home page content goes here.</CardDescription>
+					<CardDescription>
+						Post-login home page content goes here.
+					</CardDescription>
 				</CardHeader>
 				<CardContent>
 					<p className="text-sm text-muted-foreground">
@@ -21,5 +23,5 @@ export function HomePage() {
 				</CardContent>
 			</Card>
 		</main>
-	)
+	);
 }

--- a/apps/react-frontend/src/features/posts/hooks/useCreatePostForm.test.ts
+++ b/apps/react-frontend/src/features/posts/hooks/useCreatePostForm.test.ts
@@ -14,9 +14,9 @@
  *  - @repo/ui                          toast          vi.mock
  */
 
-import { createElement, act  } from "react"
-import { createRoot } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock functions (must be defined before vi.mock calls)
@@ -28,7 +28,7 @@ const { mockNavigate, mockToastSuccess, mockToastError, mockGetToken } =
 		mockToastSuccess: vi.fn(),
 		mockToastError: vi.fn(),
 		mockGetToken: vi.fn<() => string | null>(),
-	}))
+	}));
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -36,18 +36,18 @@ const { mockNavigate, mockToastSuccess, mockToastError, mockGetToken } =
 
 vi.mock("@/generated/sdk.gen", () => ({
 	postV1Posts: vi.fn(),
-}))
+}));
 
 vi.mock("@/utils/tokenStorage", () => ({
 	getToken: mockGetToken,
-}))
+}));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => mockNavigate,
-}))
+}));
 
 vi.mock("@repo/ui", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("@repo/ui")>()
+	const actual = await importOriginal<typeof import("@repo/ui")>();
 	return {
 		...actual,
 		toast: {
@@ -55,21 +55,21 @@ vi.mock("@repo/ui", async (importOriginal) => {
 			success: mockToastSuccess,
 			error: mockToastError,
 		},
-	}
-})
+	};
+});
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { postV1Posts } from "@/generated/sdk.gen"
-import { useCreatePostForm } from "@/features/posts/hooks/useCreatePostForm"
+import { useCreatePostForm } from "@/features/posts/hooks/useCreatePostForm";
+import { postV1Posts } from "@/generated/sdk.gen";
 
 // ---------------------------------------------------------------------------
 // Typed mock references
 // ---------------------------------------------------------------------------
 
-const mockPostV1Posts = postV1Posts as ReturnType<typeof vi.fn>
+const mockPostV1Posts = postV1Posts as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // TestComponent
@@ -87,12 +87,12 @@ const mockPostV1Posts = postV1Posts as ReturnType<typeof vi.fn>
 // ---------------------------------------------------------------------------
 
 function TestComponent(): React.ReactElement {
-	const { form, onSubmit, charCount } = useCreatePostForm()
+	const { form, onSubmit, charCount } = useCreatePostForm();
 	const {
 		register,
 		handleSubmit,
 		formState: { errors, isSubmitting },
-	} = form
+	} = form;
 
 	return createElement(
 		"form",
@@ -100,11 +100,7 @@ function TestComponent(): React.ReactElement {
 		createElement("textarea", {
 			...register("content"),
 		}),
-		createElement(
-			"span",
-			{ "data-testid": "char-count" },
-			String(charCount),
-		),
+		createElement("span", { "data-testid": "char-count" }, String(charCount)),
 		errors.content &&
 			createElement(
 				"p",
@@ -116,7 +112,7 @@ function TestComponent(): React.ReactElement {
 			{ type: "submit", disabled: isSubmitting },
 			"Submit",
 		),
-	)
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -124,21 +120,23 @@ function TestComponent(): React.ReactElement {
 // ---------------------------------------------------------------------------
 
 function mountTestComponent(): HTMLDivElement {
-	const container = document.createElement("div")
-	document.body.append(container)
+	const container = document.createElement("div");
+	document.body.append(container);
 	act(() => {
-		createRoot(container).render(createElement(TestComponent))
-	})
-	return container
+		createRoot(container).render(createElement(TestComponent));
+	});
+	return container;
 }
 
 async function submitForm(form: HTMLFormElement): Promise<void> {
 	await act(async () => {
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		// Allow react-hook-form's async validation + submit handler to resolve
-		await Promise.resolve()
-		await Promise.resolve()
-	})
+		await Promise.resolve();
+		await Promise.resolve();
+	});
 }
 
 function fillTextarea(textarea: HTMLTextAreaElement, value: string): void {
@@ -146,16 +144,16 @@ function fillTextarea(textarea: HTMLTextAreaElement, value: string): void {
 		const nativeValueSetter = Object.getOwnPropertyDescriptor(
 			HTMLTextAreaElement.prototype,
 			"value",
-		)?.set
-		nativeValueSetter?.call(textarea, value)
-		textarea.dispatchEvent(new Event("input", { bubbles: true }))
-		textarea.dispatchEvent(new Event("change", { bubbles: true }))
-	})
+		)?.set;
+		nativeValueSetter?.call(textarea, value);
+		textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		textarea.dispatchEvent(new Event("change", { bubbles: true }));
+	});
 }
 
 function clearBody(): void {
 	while (document.body.firstChild) {
-		document.body.firstChild.remove()
+		document.body.firstChild.remove();
 	}
 }
 
@@ -164,18 +162,18 @@ function clearBody(): void {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	vi.stubEnv("VITE_API_BASE_URL", "http://localhost:8080")
-	mockPostV1Posts.mockReset()
-	mockNavigate.mockReset()
-	mockToastSuccess.mockReset()
-	mockToastError.mockReset()
-	mockGetToken.mockReset()
-})
+	vi.stubEnv("VITE_API_BASE_URL", "http://localhost:8080");
+	mockPostV1Posts.mockReset();
+	mockNavigate.mockReset();
+	mockToastSuccess.mockReset();
+	mockToastError.mockReset();
+	mockGetToken.mockReset();
+});
 
 afterEach(() => {
-	clearBody()
-	vi.unstubAllEnvs()
-})
+	clearBody();
+	vi.unstubAllEnvs();
+});
 
 // ---------------------------------------------------------------------------
 // Tests — rendering / auth redirect
@@ -183,21 +181,21 @@ afterEach(() => {
 
 describe("useCreatePostForm — auth redirect on mount", () => {
 	it("redirects to /login when no token is present on mount", () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		mountTestComponent()
+		mountTestComponent();
 
-		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" })
-	})
+		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" });
+	});
 
 	it("does not redirect when a token is present on mount", () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 
-		mountTestComponent()
+		mountTestComponent();
 
-		expect(mockNavigate).not.toHaveBeenCalled()
-	})
-})
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — client-side validation
@@ -205,62 +203,68 @@ describe("useCreatePostForm — auth redirect on mount", () => {
 
 describe("useCreatePostForm — client-side validation", () => {
 	it("shows an error when content is empty on submit", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 
-		const container = mountTestComponent()
-		const form = container.querySelector<HTMLFormElement>("form")
-		expect(form).not.toBeNull()
+		const container = mountTestComponent();
+		const form = container.querySelector<HTMLFormElement>("form");
+		expect(form).not.toBeNull();
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
 		// Validation must surface an error — postV1Posts must not be called
-		expect(mockPostV1Posts).not.toHaveBeenCalled()
+		expect(mockPostV1Posts).not.toHaveBeenCalled();
 		// The error message should be visible in the DOM
-		const errorEl = container.querySelector<HTMLElement>("[data-testid='content-error']")
-		expect(errorEl).not.toBeNull()
-	})
+		const errorEl = container.querySelector<HTMLElement>(
+			"[data-testid='content-error']",
+		);
+		expect(errorEl).not.toBeNull();
+	});
 
 	it("shows 'Content must be 280 characters or less' when content exceeds 280 characters", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
-		expect(textarea).not.toBeNull()
-		expect(form).not.toBeNull()
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
+		expect(textarea).not.toBeNull();
+		expect(form).not.toBeNull();
 
 		// 281 characters — one over the limit
-		fillTextarea(textarea as HTMLTextAreaElement, "a".repeat(281))
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, "a".repeat(281));
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockPostV1Posts).not.toHaveBeenCalled()
+		expect(mockPostV1Posts).not.toHaveBeenCalled();
 		expect(container.textContent).toContain(
 			"Content must be 280 characters or less",
-		)
-	})
+		);
+	});
 
 	it("does not show a validation error when content is exactly 280 characters", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		mockPostV1Posts.mockResolvedValue({
-			data: { id: "post-1", content: "a".repeat(280), createdAt: "2026-03-14T00:00:00Z" },
+			data: {
+				id: "post-1",
+				content: "a".repeat(280),
+				createdAt: "2026-03-14T00:00:00Z",
+			},
 			error: undefined,
 			response: { status: 201 },
-		})
+		});
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
-		expect(textarea).not.toBeNull()
-		expect(form).not.toBeNull()
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
+		expect(textarea).not.toBeNull();
+		expect(form).not.toBeNull();
 
-		fillTextarea(textarea as HTMLTextAreaElement, "a".repeat(280))
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, "a".repeat(280));
+		await submitForm(form as HTMLFormElement);
 
 		expect(container.textContent).not.toContain(
 			"Content must be 280 characters or less",
-		)
-	})
-})
+		);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — charCount
@@ -268,104 +272,104 @@ describe("useCreatePostForm — client-side validation", () => {
 
 describe("useCreatePostForm — charCount", () => {
 	it("reflects the current character count of the content field", () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		expect(textarea).not.toBeNull()
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		expect(textarea).not.toBeNull();
 
-		fillTextarea(textarea as HTMLTextAreaElement, "Hello!")
+		fillTextarea(textarea as HTMLTextAreaElement, "Hello!");
 
 		const charCountEl = container.querySelector<HTMLElement>(
 			"[data-testid='char-count']",
-		)
-		expect(charCountEl?.textContent).toBe("6")
-	})
+		);
+		expect(charCountEl?.textContent).toBe("6");
+	});
 
 	it("starts at 0 before any input", () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 
-		const container = mountTestComponent()
+		const container = mountTestComponent();
 
 		const charCountEl = container.querySelector<HTMLElement>(
 			"[data-testid='char-count']",
-		)
-		expect(charCountEl?.textContent).toBe("0")
-	})
-})
+		);
+		expect(charCountEl?.textContent).toBe("0");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — happy path submit
 // ---------------------------------------------------------------------------
 
 describe("useCreatePostForm — successful submit", () => {
-	const VALID_CONTENT = "Hello, world!"
+	const VALID_CONTENT = "Hello, world!";
 	const MOCK_RESPONSE = {
 		id: "post-abc",
 		content: VALID_CONTENT,
 		createdAt: "2026-03-14T00:00:00Z",
-	}
+	};
 
 	it("calls postV1Posts with the entered content", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		mockPostV1Posts.mockResolvedValue({
 			data: MOCK_RESPONSE,
 			error: undefined,
 			response: { status: 201 },
-		})
+		});
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, VALID_CONTENT)
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, VALID_CONTENT);
+		await submitForm(form as HTMLFormElement);
 
 		expect(mockPostV1Posts).toHaveBeenCalledWith(
 			expect.objectContaining({ body: { content: VALID_CONTENT } }),
-		)
-	})
+		);
+	});
 
 	it("shows a success toast after a successful submit", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		mockPostV1Posts.mockResolvedValue({
 			data: MOCK_RESPONSE,
 			error: undefined,
 			response: { status: 201 },
-		})
+		});
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, VALID_CONTENT)
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, VALID_CONTENT);
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockToastSuccess).toHaveBeenCalledTimes(1)
-	})
+		expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+	});
 
 	it("resets the form after a successful submit", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		mockPostV1Posts.mockResolvedValue({
 			data: MOCK_RESPONSE,
 			error: undefined,
 			response: { status: 201 },
-		})
+		});
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, VALID_CONTENT)
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, VALID_CONTENT);
+		await submitForm(form as HTMLFormElement);
 
 		// After reset, the textarea value should be empty and charCount back to 0
 		const charCountEl = container.querySelector<HTMLElement>(
 			"[data-testid='char-count']",
-		)
-		expect(charCountEl?.textContent).toBe("0")
-	})
-})
+		);
+		expect(charCountEl?.textContent).toBe("0");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — submit loading state
@@ -373,25 +377,23 @@ describe("useCreatePostForm — successful submit", () => {
 
 describe("useCreatePostForm — loading state", () => {
 	it("disables the submit button while the API call is in-flight", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		// Never resolves — keeps isSubmitting true
-		mockPostV1Posts.mockImplementation(
-			() => new Promise<never>(() => {}),
-		)
+		mockPostV1Posts.mockImplementation(() => new Promise<never>(() => {}));
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, "Some post content")
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, "Some post content");
+		await submitForm(form as HTMLFormElement);
 
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn?.disabled).toBe(true)
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn?.disabled).toBe(true);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — error path submit
@@ -399,72 +401,76 @@ describe("useCreatePostForm — loading state", () => {
 
 describe("useCreatePostForm — failed submit", () => {
 	it("navigates to /login on a 401 error from postV1Posts", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		mockPostV1Posts.mockResolvedValue({
 			data: undefined,
 			error: { type: "UNAUTHORIZED", title: "Unauthorized", status: 401 },
 			response: { status: 401 },
-		})
+		});
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, "Some post content")
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, "Some post content");
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" })
-	})
+		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" });
+	});
 
 	it("shows an error toast on a 500 server error", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		mockPostV1Posts.mockResolvedValue({
 			data: undefined,
-			error: { type: "INTERNAL_ERROR", title: "Internal Server Error", status: 500 },
+			error: {
+				type: "INTERNAL_ERROR",
+				title: "Internal Server Error",
+				status: 500,
+			},
 			response: { status: 500 },
-		})
+		});
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, "Some post content")
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, "Some post content");
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockToastError).toHaveBeenCalledTimes(1)
-		expect(mockNavigate).not.toHaveBeenCalled()
-	})
+		expect(mockToastError).toHaveBeenCalledTimes(1);
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
 
 	it("shows an error toast on a network-level failure", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
-		mockPostV1Posts.mockRejectedValue(new Error("Network failure"))
+		mockGetToken.mockReturnValue("valid-jwt-token");
+		mockPostV1Posts.mockRejectedValue(new Error("Network failure"));
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, "Some post content")
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, "Some post content");
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockToastError).toHaveBeenCalledTimes(1)
-		expect(mockNavigate).not.toHaveBeenCalled()
-	})
+		expect(mockToastError).toHaveBeenCalledTimes(1);
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
 
 	it("does not navigate to /login on a non-401 error", async () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 		mockPostV1Posts.mockResolvedValue({
 			data: undefined,
 			error: { type: "FORBIDDEN", title: "Forbidden", status: 403 },
 			response: { status: 403 },
-		})
+		});
 
-		const container = mountTestComponent()
-		const textarea = container.querySelector<HTMLTextAreaElement>("textarea")
-		const form = container.querySelector<HTMLFormElement>("form")
+		const container = mountTestComponent();
+		const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+		const form = container.querySelector<HTMLFormElement>("form");
 
-		fillTextarea(textarea as HTMLTextAreaElement, "Some post content")
-		await submitForm(form as HTMLFormElement)
+		fillTextarea(textarea as HTMLTextAreaElement, "Some post content");
+		await submitForm(form as HTMLFormElement);
 
-		expect(mockNavigate).not.toHaveBeenCalled()
-	})
-})
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/react-frontend/src/features/posts/hooks/useCreatePostForm.ts
+++ b/apps/react-frontend/src/features/posts/hooks/useCreatePostForm.ts
@@ -1,75 +1,75 @@
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useNavigate } from '@tanstack/react-router'
-import { toast } from '@repo/ui'
-import { useEffect } from 'react'
-import { useForm, useWatch } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
-import { z } from 'zod'
-import { postV1Posts } from '@/generated/sdk.gen'
-import { getToken } from '@/utils/tokenStorage'
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "@repo/ui";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+import { postV1Posts } from "@/generated/sdk.gen";
+import { getToken } from "@/utils/tokenStorage";
 
 function useCreatePostFormSchema() {
-  const { t } = useTranslation()
-  return z.object({
-    content: z
-      .string()
-      .min(1, t('posts.new.validation.contentRequired'))
-      .max(280, t('posts.new.validation.contentTooLong')),
-  })
+	const { t } = useTranslation();
+	return z.object({
+		content: z
+			.string()
+			.min(1, t("posts.new.validation.contentRequired"))
+			.max(280, t("posts.new.validation.contentTooLong")),
+	});
 }
 
-type CreatePostFormValues = z.infer<ReturnType<typeof useCreatePostFormSchema>>
+type CreatePostFormValues = z.infer<ReturnType<typeof useCreatePostFormSchema>>;
 
 export function useCreatePostForm() {
-  const { t } = useTranslation()
-  const navigate = useNavigate()
-  const schema = useCreatePostFormSchema()
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const schema = useCreatePostFormSchema();
 
-  const form = useForm<CreatePostFormValues>({
-    resolver: zodResolver(schema),
-    defaultValues: { content: '' },
-  })
+	const form = useForm<CreatePostFormValues>({
+		resolver: zodResolver(schema),
+		defaultValues: { content: "" },
+	});
 
-  // Redirect to login if no token is present on mount.
-  // getToken() reads localStorage synchronously and is not reactive, so it is
-  // intentionally omitted from the dependency array.
-  useEffect(() => {
-    if (getToken() === null) {
-      void navigate({ to: '/login' })
-    }
-  }, [navigate])
+	// Redirect to login if no token is present on mount.
+	// getToken() reads localStorage synchronously and is not reactive, so it is
+	// intentionally omitted from the dependency array.
+	useEffect(() => {
+		if (getToken() === null) {
+			void navigate({ to: "/login" });
+		}
+	}, [navigate]);
 
-  // useWatch scopes re-renders to this consumer only, avoiding a full form
-  // re-render on every keystroke that form.watch() would cause.
-  // useWatch returns undefined before RHF initialises its internal state on the
-  // first render. The nullish fallback ensures charCount is always a number.
-  const content = useWatch({ control: form.control, name: 'content' }) ?? ''
-  const charCount = content.length
+	// useWatch scopes re-renders to this consumer only, avoiding a full form
+	// re-render on every keystroke that form.watch() would cause.
+	// useWatch returns undefined before RHF initialises its internal state on the
+	// first render. The nullish fallback ensures charCount is always a number.
+	const content = useWatch({ control: form.control, name: "content" }) ?? "";
+	const charCount = content.length;
 
-  async function onSubmit(values: CreatePostFormValues) {
-    try {
-      const token = getToken()
-      const { data, error, response } = await postV1Posts({
-        body: { content: values.content },
-        baseUrl: import.meta.env.VITE_API_BASE_URL,
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-      })
-      if (error || !data) throw new Error(String(response.status))
-      toast.success(t('posts.new.success'))
-      form.reset()
-    } catch (error) {
-      // postV1Posts throws on network-level failures; for HTTP errors we throw
-      // new Error(String(response.status)) ourselves above.
-      // Only a server-returned 401 redirects to login; all other failures show
-      // a generic toast. The pre-flight mount guard already redirects if no
-      // token is present, so an auth failure here is unexpected but handled.
-      if (error instanceof Error && error.message === '401') {
-        void navigate({ to: '/login' })
-      } else {
-        toast.error(t('posts.new.error.generic'))
-      }
-    }
-  }
+	async function onSubmit(values: CreatePostFormValues) {
+		try {
+			const token = getToken();
+			const { data, error, response } = await postV1Posts({
+				body: { content: values.content },
+				baseUrl: import.meta.env.VITE_API_BASE_URL,
+				headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+			});
+			if (error || !data) throw new Error(String(response.status));
+			toast.success(t("posts.new.success"));
+			form.reset();
+		} catch (error) {
+			// postV1Posts throws on network-level failures; for HTTP errors we throw
+			// new Error(String(response.status)) ourselves above.
+			// Only a server-returned 401 redirects to login; all other failures show
+			// a generic toast. The pre-flight mount guard already redirects if no
+			// token is present, so an auth failure here is unexpected but handled.
+			if (error instanceof Error && error.message === "401") {
+				void navigate({ to: "/login" });
+			} else {
+				toast.error(t("posts.new.error.generic"));
+			}
+		}
+	}
 
-  return { form, onSubmit, charCount }
+	return { form, onSubmit, charCount };
 }

--- a/apps/react-frontend/src/features/posts/hooks/usePostsList.test.ts
+++ b/apps/react-frontend/src/features/posts/hooks/usePostsList.test.ts
@@ -9,24 +9,24 @@
  * as data attributes on a DOM node.
  */
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { act, createElement } from "react"
-import { createRoot } from "react-dom/client"
-import type { Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import type { PostListResponse } from "@/generated/types.gen"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PostListResponse } from "@/generated/types.gen";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock factories
 // ---------------------------------------------------------------------------
 
 const { mockGetV1Posts, mockGetToken, mockNavigate } = vi.hoisted(() => {
-	const mockGetV1Posts = vi.fn()
-	const mockGetToken = vi.fn()
-	const mockNavigate = vi.fn()
+	const mockGetV1Posts = vi.fn();
+	const mockGetToken = vi.fn();
+	const mockNavigate = vi.fn();
 
-	return { mockGetV1Posts, mockGetToken, mockNavigate }
-})
+	return { mockGetV1Posts, mockGetToken, mockNavigate };
+});
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -34,94 +34,116 @@ const { mockGetV1Posts, mockGetToken, mockNavigate } = vi.hoisted(() => {
 
 vi.mock("@/generated/sdk.gen", () => ({
 	getV1Posts: mockGetV1Posts,
-}))
+}));
 
 vi.mock("@/utils/tokenStorage", () => ({
 	getToken: mockGetToken,
-}))
+}));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => mockNavigate,
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { usePostsList } from "./usePostsList"
+import { usePostsList } from "./usePostsList";
 
 // ---------------------------------------------------------------------------
 // Helpers — test component renders hook state into the DOM
 // ---------------------------------------------------------------------------
 
 function TestComponent() {
-	const { posts, total, isLoading, isError } = usePostsList()
+	const { posts, total, isLoading, isError } = usePostsList();
 
-	return createElement("div", { "data-testid": "hook-output" },
+	return createElement(
+		"div",
+		{ "data-testid": "hook-output" },
 		createElement("span", { "data-loading": String(isLoading) }),
 		createElement("span", { "data-error": String(isError) }),
-		createElement("span", { "data-total": total !== undefined ? String(total) : "" }),
-		createElement("ul", null,
+		createElement("span", {
+			"data-total": total !== undefined ? String(total) : "",
+		}),
+		createElement(
+			"ul",
+			null,
 			...(posts ?? []).map((p) =>
-				createElement("li", { key: p.id, "data-content": p.content }, p.content),
+				createElement(
+					"li",
+					{ key: p.id, "data-content": p.content },
+					p.content,
+				),
 			),
 		),
-	)
+	);
 }
 
 function makeQueryClient() {
 	return new QueryClient({
 		defaultOptions: { queries: { retry: false } },
-	})
+	});
 }
 
-function mountHook(queryClient: QueryClient): { container: HTMLDivElement; root: Root } {
-	const container = document.createElement("div")
-	document.body.append(container)
+function mountHook(queryClient: QueryClient): {
+	container: HTMLDivElement;
+	root: Root;
+} {
+	const container = document.createElement("div");
+	document.body.append(container);
 
-	let root!: Root
+	let root!: Root;
 	act(() => {
-		root = createRoot(container)
+		root = createRoot(container);
 		root.render(
-			createElement(QueryClientProvider, { client: queryClient }, createElement(TestComponent)),
-		)
-	})
+			createElement(
+				QueryClientProvider,
+				{ client: queryClient },
+				createElement(TestComponent),
+			),
+		);
+	});
 
-	return { container, root }
+	return { container, root };
 }
 
 function getOutput(container: HTMLDivElement) {
-	const el = container.querySelector("[data-testid='hook-output']")
-	const isLoading = (el?.querySelector("[data-loading]") as HTMLElement | null)?.dataset.loading === "true"
-	const isError = (el?.querySelector("[data-error]") as HTMLElement | null)?.dataset.error === "true"
-	const totalAttr = (el?.querySelector("[data-total]") as HTMLElement | null)?.dataset.total
-	const total = totalAttr ? Number(totalAttr) : undefined
+	const el = container.querySelector("[data-testid='hook-output']");
+	const isLoading =
+		(el?.querySelector("[data-loading]") as HTMLElement | null)?.dataset
+			.loading === "true";
+	const isError =
+		(el?.querySelector("[data-error]") as HTMLElement | null)?.dataset.error ===
+		"true";
+	const totalAttr = (el?.querySelector("[data-total]") as HTMLElement | null)
+		?.dataset.total;
+	const total = totalAttr ? Number(totalAttr) : undefined;
 	const posts = [...(el?.querySelectorAll("[data-content]") ?? [])].map(
 		(node) => (node as HTMLElement).dataset.content ?? "",
-	)
+	);
 
-	return { isLoading, isError, total, posts }
+	return { isLoading, isError, total, posts };
 }
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
-let cleanup: (() => void) | undefined
+let cleanup: (() => void) | undefined;
 
 beforeEach(() => {
-	mockGetV1Posts.mockReset()
-	mockGetToken.mockReset()
-	mockNavigate.mockReset()
-	cleanup = undefined
-})
+	mockGetV1Posts.mockReset();
+	mockGetToken.mockReset();
+	mockNavigate.mockReset();
+	cleanup = undefined;
+});
 
 afterEach(() => {
-	cleanup?.()
+	cleanup?.();
 	while (document.body.firstChild) {
-		document.body.firstChild.remove()
+		document.body.firstChild.remove();
 	}
-})
+});
 
 // ---------------------------------------------------------------------------
 // Tests — happy path
@@ -129,7 +151,7 @@ afterEach(() => {
 
 describe("usePostsList — happy path", () => {
 	it("returns posts and total when fetch succeeds", async () => {
-		mockGetToken.mockReturnValue("test-token")
+		mockGetToken.mockReturnValue("test-token");
 		const mockData: PostListResponse = {
 			posts: [
 				{
@@ -142,45 +164,68 @@ describe("usePostsList — happy path", () => {
 			total: 1,
 			limit: 20,
 			offset: 0,
-		}
-		mockGetV1Posts.mockResolvedValue({ data: mockData, error: undefined, response: { status: 200 } })
+		};
+		mockGetV1Posts.mockResolvedValue({
+			data: mockData,
+			error: undefined,
+			response: { status: 200 },
+		});
 
-		const queryClient = makeQueryClient()
-		const { container, root } = mountHook(queryClient)
-		cleanup = () => { act(() => { root.unmount() }); container.remove() }
+		const queryClient = makeQueryClient();
+		const { container, root } = mountHook(queryClient);
+		cleanup = () => {
+			act(() => {
+				root.unmount();
+			});
+			container.remove();
+		};
 
 		await act(async () => {
-			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] })
-			await new Promise((resolve) => setTimeout(resolve, 0))
-		})
+			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] });
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
 
-		const output = getOutput(container)
-		expect(output.posts).toHaveLength(1)
-		expect(output.posts[0]).toBe("Hello world")
-		expect(output.total).toBe(1)
-		expect(output.isLoading).toBe(false)
-		expect(output.isError).toBe(false)
-	})
+		const output = getOutput(container);
+		expect(output.posts).toHaveLength(1);
+		expect(output.posts[0]).toBe("Hello world");
+		expect(output.total).toBe(1);
+		expect(output.isLoading).toBe(false);
+		expect(output.isError).toBe(false);
+	});
 
 	it("returns empty posts array when response is empty", async () => {
-		mockGetToken.mockReturnValue("test-token")
-		const mockData: PostListResponse = { posts: [], total: 0, limit: 20, offset: 0 }
-		mockGetV1Posts.mockResolvedValue({ data: mockData, error: undefined, response: { status: 200 } })
+		mockGetToken.mockReturnValue("test-token");
+		const mockData: PostListResponse = {
+			posts: [],
+			total: 0,
+			limit: 20,
+			offset: 0,
+		};
+		mockGetV1Posts.mockResolvedValue({
+			data: mockData,
+			error: undefined,
+			response: { status: 200 },
+		});
 
-		const queryClient = makeQueryClient()
-		const { container, root } = mountHook(queryClient)
-		cleanup = () => { act(() => { root.unmount() }); container.remove() }
+		const queryClient = makeQueryClient();
+		const { container, root } = mountHook(queryClient);
+		cleanup = () => {
+			act(() => {
+				root.unmount();
+			});
+			container.remove();
+		};
 
 		await act(async () => {
-			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] })
-			await new Promise((resolve) => setTimeout(resolve, 0))
-		})
+			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] });
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
 
-		const output = getOutput(container)
-		expect(output.posts).toHaveLength(0)
-		expect(output.total).toBe(0)
-	})
-})
+		const output = getOutput(container);
+		expect(output.posts).toHaveLength(0);
+		expect(output.total).toBe(0);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — error path
@@ -188,44 +233,54 @@ describe("usePostsList — happy path", () => {
 
 describe("usePostsList — error path", () => {
 	it("sets isError to true when API returns an error", async () => {
-		mockGetToken.mockReturnValue("test-token")
+		mockGetToken.mockReturnValue("test-token");
 		mockGetV1Posts.mockResolvedValue({
 			data: undefined,
 			error: { type: "INTERNAL_SERVER_ERROR" },
 			response: { status: 500 },
-		})
+		});
 
-		const queryClient = makeQueryClient()
-		const { container, root } = mountHook(queryClient)
-		cleanup = () => { act(() => { root.unmount() }); container.remove() }
+		const queryClient = makeQueryClient();
+		const { container, root } = mountHook(queryClient);
+		cleanup = () => {
+			act(() => {
+				root.unmount();
+			});
+			container.remove();
+		};
 
 		await act(async () => {
-			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] })
-			await new Promise((resolve) => setTimeout(resolve, 0))
-		})
+			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] });
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
 
-		const output = getOutput(container)
-		expect(output.isError).toBe(true)
-		expect(output.posts).toHaveLength(0)
-	})
+		const output = getOutput(container);
+		expect(output.isError).toBe(true);
+		expect(output.posts).toHaveLength(0);
+	});
 
 	it("sets isError to true when fetch throws a network error", async () => {
-		mockGetToken.mockReturnValue("test-token")
-		mockGetV1Posts.mockRejectedValue(new Error("Network error"))
+		mockGetToken.mockReturnValue("test-token");
+		mockGetV1Posts.mockRejectedValue(new Error("Network error"));
 
-		const queryClient = makeQueryClient()
-		const { container, root } = mountHook(queryClient)
-		cleanup = () => { act(() => { root.unmount() }); container.remove() }
+		const queryClient = makeQueryClient();
+		const { container, root } = mountHook(queryClient);
+		cleanup = () => {
+			act(() => {
+				root.unmount();
+			});
+			container.remove();
+		};
 
 		await act(async () => {
-			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] })
-			await new Promise((resolve) => setTimeout(resolve, 0))
-		})
+			await queryClient.invalidateQueries({ queryKey: ["posts", "list"] });
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
 
-		const output = getOutput(container)
-		expect(output.isError).toBe(true)
-	})
-})
+		const output = getOutput(container);
+		expect(output.isError).toBe(true);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — API integration (token header)
@@ -233,52 +288,76 @@ describe("usePostsList — error path", () => {
 
 describe("usePostsList — API integration", () => {
 	it("calls getV1Posts with a Bearer token header when token is present", async () => {
-		mockGetToken.mockReturnValue("my-secret-token")
-		const mockData: PostListResponse = { posts: [], total: 0, limit: 20, offset: 0 }
-		mockGetV1Posts.mockResolvedValue({ data: mockData, error: undefined, response: { status: 200 } })
+		mockGetToken.mockReturnValue("my-secret-token");
+		const mockData: PostListResponse = {
+			posts: [],
+			total: 0,
+			limit: 20,
+			offset: 0,
+		};
+		mockGetV1Posts.mockResolvedValue({
+			data: mockData,
+			error: undefined,
+			response: { status: 200 },
+		});
 
-		const queryClient = makeQueryClient()
-		const { container, root } = mountHook(queryClient)
-		cleanup = () => { act(() => { root.unmount() }); container.remove() }
+		const queryClient = makeQueryClient();
+		const { container, root } = mountHook(queryClient);
+		cleanup = () => {
+			act(() => {
+				root.unmount();
+			});
+			container.remove();
+		};
 
 		await act(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 0))
-		})
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
 
-		expect(mockGetV1Posts).toHaveBeenCalledOnce()
+		expect(mockGetV1Posts).toHaveBeenCalledOnce();
 		expect(mockGetV1Posts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				headers: { Authorization: "Bearer my-secret-token" },
 			}),
-		)
-	})
+		);
+	});
 
 	it("does not call getV1Posts when token is null (query disabled)", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		const queryClient = makeQueryClient()
-		const { container, root } = mountHook(queryClient)
-		cleanup = () => { act(() => { root.unmount() }); container.remove() }
+		const queryClient = makeQueryClient();
+		const { container, root } = mountHook(queryClient);
+		cleanup = () => {
+			act(() => {
+				root.unmount();
+			});
+			container.remove();
+		};
 
 		await act(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 0))
-		})
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
 
-		expect(mockGetV1Posts).not.toHaveBeenCalled()
-	})
+		expect(mockGetV1Posts).not.toHaveBeenCalled();
+	});
 
 	it("redirects to login and does not call getV1Posts when token is null", async () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		const queryClient = makeQueryClient()
-		const { container, root } = mountHook(queryClient)
-		cleanup = () => { act(() => { root.unmount() }); container.remove() }
+		const queryClient = makeQueryClient();
+		const { container, root } = mountHook(queryClient);
+		cleanup = () => {
+			act(() => {
+				root.unmount();
+			});
+			container.remove();
+		};
 
 		await act(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 0))
-		})
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
 
-		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" })
-		expect(mockGetV1Posts).not.toHaveBeenCalled()
-	})
-})
+		expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" });
+		expect(mockGetV1Posts).not.toHaveBeenCalled();
+	});
+});

--- a/apps/react-frontend/src/features/posts/hooks/usePostsList.ts
+++ b/apps/react-frontend/src/features/posts/hooks/usePostsList.ts
@@ -1,48 +1,48 @@
-import { useQuery } from "@tanstack/react-query"
-import { useEffect } from "react"
-import { useNavigate } from "@tanstack/react-router"
-import { getV1Posts } from "@/generated/sdk.gen"
-import type { PostListResponse } from "@/generated/types.gen"
-import { getToken } from "@/utils/tokenStorage"
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { getV1Posts } from "@/generated/sdk.gen";
+import type { PostListResponse } from "@/generated/types.gen";
+import { getToken } from "@/utils/tokenStorage";
 
 interface UsePostsListResult {
-	posts: PostListResponse["posts"] | undefined
-	total: number | undefined
-	isLoading: boolean
-	isError: boolean
+	posts: PostListResponse["posts"] | undefined;
+	total: number | undefined;
+	isLoading: boolean;
+	isError: boolean;
 }
 
 export function usePostsList(): UsePostsListResult {
-	const navigate = useNavigate()
+	const navigate = useNavigate();
 
 	// Redirect to login if no token is present on mount.
 	// getToken() reads localStorage synchronously and is not reactive, so it is
 	// intentionally omitted from the dependency array.
 	useEffect(() => {
 		if (getToken() === null) {
-			void navigate({ to: "/login" })
+			void navigate({ to: "/login" });
 		}
-	}, [navigate])
+	}, [navigate]);
 
 	const { data, isLoading, isError } = useQuery({
 		queryKey: ["posts", "list"],
 		enabled: getToken() !== null,
 		queryFn: async () => {
-			const token = getToken()
+			const token = getToken();
 			const { data, error } = await getV1Posts({
 				baseUrl: import.meta.env.VITE_API_BASE_URL,
 				headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-			})
-			if (error || !data) throw new Error("Failed to fetch posts")
+			});
+			if (error || !data) throw new Error("Failed to fetch posts");
 
-			return data
+			return data;
 		},
-	})
+	});
 
 	return {
 		posts: data?.posts,
 		total: data?.total,
 		isLoading,
 		isError,
-	}
+	};
 }

--- a/apps/react-frontend/src/features/posts/pages/NewPostPage.test.tsx
+++ b/apps/react-frontend/src/features/posts/pages/NewPostPage.test.tsx
@@ -16,37 +16,36 @@
  *  - @repo/ui                                  Form component stubs vi.mock
  */
 
-import type React from "react"
-import { act } from "react"
-import { createRoot } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock factories
 // ---------------------------------------------------------------------------
 
 const { mockReset, makeFormObject } = vi.hoisted(() => {
-	const mockReset = vi.fn()
+	const mockReset = vi.fn();
 
 	function makeFormObject(isSubmitting: boolean) {
 		return {
 			// handleSubmit wraps the caller-supplied onSubmit so that form submission
 			// is synchronous and testable without needing real RHF internals.
 			handleSubmit:
-				(fn: (values: { content: string }) => void) =>
-				(e: React.FormEvent) => {
-					e.preventDefault()
-					fn({ content: "" })
+				(fn: (values: { content: string }) => void) => (e: React.FormEvent) => {
+					e.preventDefault();
+					fn({ content: "" });
 				},
 			control: {},
 			formState: { isSubmitting },
 			register: () => ({}),
 			reset: mockReset,
-		}
+		};
 	}
 
-	return { mockReset, makeFormObject }
-})
+	return { mockReset, makeFormObject };
+});
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -56,7 +55,7 @@ const { mockReset, makeFormObject } = vi.hoisted(() => {
 // FormField calls its render prop with a minimal field object so the Textarea
 // inside renders normally and is queryable via DOM selectors.
 vi.mock("@repo/ui", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("@repo/ui")>()
+	const actual = await importOriginal<typeof import("@repo/ui")>();
 	return {
 		...actual,
 		Form: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -65,13 +64,13 @@ vi.mock("@repo/ui", async (importOriginal) => {
 		}: {
 			render: (args: {
 				field: {
-					value: string
-					onChange: () => void
-					onBlur: () => void
-					name: string
-					ref: () => void
-				}
-			}) => React.ReactNode
+					value: string;
+					onChange: () => void;
+					onBlur: () => void;
+					name: string;
+					ref: () => void;
+				};
+			}) => React.ReactNode;
 		}) =>
 			render({
 				field: {
@@ -92,12 +91,12 @@ vi.mock("@repo/ui", async (importOriginal) => {
 			children,
 			htmlFor,
 		}: {
-			children: React.ReactNode
-			htmlFor?: string
+			children: React.ReactNode;
+			htmlFor?: string;
 		}) => <label htmlFor={htmlFor}>{children}</label>,
 		FormMessage: () => null,
-	}
-})
+	};
+});
 
 // Default: not submitting, charCount starts at 0.
 vi.mock("@/features/posts/hooks/useCreatePostForm", () => ({
@@ -106,45 +105,47 @@ vi.mock("@/features/posts/hooks/useCreatePostForm", () => ({
 		onSubmit: vi.fn(),
 		charCount: 0,
 	})),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { useCreatePostForm } from "@/features/posts/hooks/useCreatePostForm"
-import { NewPostPage } from "./NewPostPage"
+import { useCreatePostForm } from "@/features/posts/hooks/useCreatePostForm";
+import { NewPostPage } from "./NewPostPage";
 
 // ---------------------------------------------------------------------------
 // Typed mock reference
 // ---------------------------------------------------------------------------
 
-const mockUseCreatePostForm = useCreatePostForm as ReturnType<typeof vi.fn>
+const mockUseCreatePostForm = useCreatePostForm as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function mountNewPostPage(): HTMLDivElement {
-	const container = document.createElement("div")
-	document.body.append(container)
+	const container = document.createElement("div");
+	document.body.append(container);
 	act(() => {
-		createRoot(container).render(<NewPostPage />)
-	})
-	return container
+		createRoot(container).render(<NewPostPage />);
+	});
+	return container;
 }
 
 async function submitForm(form: HTMLFormElement): Promise<void> {
 	await act(async () => {
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
-		await Promise.resolve()
-		await Promise.resolve()
-	})
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+	});
 }
 
 function clearBody(): void {
 	while (document.body.firstChild) {
-		document.body.firstChild.remove()
+		document.body.firstChild.remove();
 	}
 }
 
@@ -153,18 +154,18 @@ function clearBody(): void {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	mockReset.mockReset()
+	mockReset.mockReset();
 	// Restore the default mock return value before each test.
 	mockUseCreatePostForm.mockReturnValue({
 		form: makeFormObject(false),
 		onSubmit: vi.fn(),
 		charCount: 0,
-	})
-})
+	});
+});
 
 afterEach(() => {
-	clearBody()
-})
+	clearBody();
+});
 
 // ---------------------------------------------------------------------------
 // Tests — rendering
@@ -172,39 +173,39 @@ afterEach(() => {
 
 describe("NewPostPage — rendering", () => {
 	it("renders a heading containing 'New Post'", () => {
-		const container = mountNewPostPage()
-		expect(container.textContent).toContain("New Post")
-	})
+		const container = mountNewPostPage();
+		expect(container.textContent).toContain("New Post");
+	});
 
 	it("renders a form element", () => {
-		const container = mountNewPostPage()
-		const form = container.querySelector<HTMLFormElement>("form")
-		expect(form).not.toBeNull()
-	})
+		const container = mountNewPostPage();
+		const form = container.querySelector<HTMLFormElement>("form");
+		expect(form).not.toBeNull();
+	});
 
 	it("renders a textarea for the content field", () => {
-		const container = mountNewPostPage()
+		const container = mountNewPostPage();
 		const textarea =
 			container.querySelector<HTMLTextAreaElement>("textarea") ??
 			container.querySelector<HTMLInputElement>(
 				'input[name="content"], input[placeholder*="content" i]',
-			)
-		expect(textarea).not.toBeNull()
-	})
+			);
+		expect(textarea).not.toBeNull();
+	});
 
 	it("renders a submit button", () => {
-		const container = mountNewPostPage()
+		const container = mountNewPostPage();
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn).not.toBeNull()
-	})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn).not.toBeNull();
+	});
 
 	it("shows character count '0 / 280' initially", () => {
-		const container = mountNewPostPage()
-		expect(container.textContent).toContain("0 / 280")
-	})
-})
+		const container = mountNewPostPage();
+		expect(container.textContent).toContain("0 / 280");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — submit button disabled state
@@ -216,31 +217,31 @@ describe("NewPostPage — submit button disabled state", () => {
 			form: makeFormObject(true),
 			onSubmit: vi.fn(),
 			charCount: 0,
-		})
+		});
 
-		const container = mountNewPostPage()
+		const container = mountNewPostPage();
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn).not.toBeNull()
-		expect(submitBtn?.disabled).toBe(true)
-	})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn).not.toBeNull();
+		expect(submitBtn?.disabled).toBe(true);
+	});
 
 	it("enables the submit button when isSubmitting is false", () => {
 		mockUseCreatePostForm.mockReturnValue({
 			form: makeFormObject(false),
 			onSubmit: vi.fn(),
 			charCount: 0,
-		})
+		});
 
-		const container = mountNewPostPage()
+		const container = mountNewPostPage();
 		const submitBtn =
 			container.querySelector<HTMLButtonElement>('button[type="submit"]') ??
-			container.querySelector<HTMLButtonElement>("button")
-		expect(submitBtn).not.toBeNull()
-		expect(submitBtn?.disabled).toBe(false)
-	})
-})
+			container.querySelector<HTMLButtonElement>("button");
+		expect(submitBtn).not.toBeNull();
+		expect(submitBtn?.disabled).toBe(false);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — form submission wiring
@@ -250,13 +251,12 @@ describe("NewPostPage — form submission wiring", () => {
 	it("calls form.handleSubmit(onSubmit) when the form is submitted", async () => {
 		// Provide a spy for handleSubmit so we can assert it was invoked.
 		const handleSubmitSpy = vi.fn(
-			(fn: (values: { content: string }) => void) =>
-				(e: React.FormEvent) => {
-					e.preventDefault()
-					fn({ content: "" })
-				},
-		)
-		const onSubmitSpy = vi.fn()
+			(fn: (values: { content: string }) => void) => (e: React.FormEvent) => {
+				e.preventDefault();
+				fn({ content: "" });
+			},
+		);
+		const onSubmitSpy = vi.fn();
 
 		mockUseCreatePostForm.mockReturnValue({
 			form: {
@@ -265,15 +265,15 @@ describe("NewPostPage — form submission wiring", () => {
 			},
 			onSubmit: onSubmitSpy,
 			charCount: 0,
-		})
+		});
 
-		const container = mountNewPostPage()
-		const form = container.querySelector<HTMLFormElement>("form")
-		expect(form).not.toBeNull()
+		const container = mountNewPostPage();
+		const form = container.querySelector<HTMLFormElement>("form");
+		expect(form).not.toBeNull();
 
-		await submitForm(form as HTMLFormElement)
+		await submitForm(form as HTMLFormElement);
 
 		// handleSubmit must have been called with the page's onSubmit handler.
-		expect(handleSubmitSpy).toHaveBeenCalledWith(onSubmitSpy)
-	})
-})
+		expect(handleSubmitSpy).toHaveBeenCalledWith(onSubmitSpy);
+	});
+});

--- a/apps/react-frontend/src/features/posts/pages/NewPostPage.tsx
+++ b/apps/react-frontend/src/features/posts/pages/NewPostPage.tsx
@@ -8,18 +8,18 @@ import {
 	FormMessage,
 	Heading,
 	Textarea,
-} from '@repo/ui'
-import { useTranslation } from 'react-i18next'
-import { useCreatePostForm } from '@/features/posts/hooks/useCreatePostForm'
+} from "@repo/ui";
+import { useTranslation } from "react-i18next";
+import { useCreatePostForm } from "@/features/posts/hooks/useCreatePostForm";
 
 export function NewPostPage() {
-	const { t } = useTranslation()
-	const { form, onSubmit, charCount } = useCreatePostForm()
+	const { t } = useTranslation();
+	const { form, onSubmit, charCount } = useCreatePostForm();
 
 	return (
 		<main className="page-wrap flex min-h-[60vh] items-center justify-center px-4 py-12">
 			<section className="island-shell w-full max-w-lg rounded-2xl p-6 sm:p-8">
-				<Heading level={1}>{t('posts.new.title')}</Heading>
+				<Heading level={1}>{t("posts.new.title")}</Heading>
 
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(onSubmit)} noValidate>
@@ -30,13 +30,10 @@ export function NewPostPage() {
 								render={({ field }) => (
 									<FormItem>
 										<FormLabel htmlFor="post-content">
-											{t('posts.new.label')}
+											{t("posts.new.label")}
 										</FormLabel>
 										<FormControl>
-											<Textarea
-												id="post-content"
-												{...field}
-											/>
+											<Textarea id="post-content" {...field} />
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -46,18 +43,18 @@ export function NewPostPage() {
 
 						<div className="mb-4 text-sm text-right">
 							<span data-testid="char-count">
-								{t('posts.new.charCount', { current: charCount, max: 280 })}
+								{t("posts.new.charCount", { current: charCount, max: 280 })}
 							</span>
 						</div>
 
 						<div className="w-full">
 							<Button type="submit" disabled={form.formState.isSubmitting}>
-								{t('posts.new.submit')}
+								{t("posts.new.submit")}
 							</Button>
 						</div>
 					</form>
 				</Form>
 			</section>
 		</main>
-	)
+	);
 }

--- a/apps/react-frontend/src/features/posts/pages/PostsListPage.test.tsx
+++ b/apps/react-frontend/src/features/posts/pages/PostsListPage.test.tsx
@@ -9,21 +9,21 @@
  *  - @/features/posts/hooks/usePostsList  usePostsList vi.mock
  */
 
-import { act } from "react"
-import { createRoot } from "react-dom/client"
-import type { Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import type { PostListResponse } from "@/generated/types.gen"
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PostListResponse } from "@/generated/types.gen";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock factories
 // ---------------------------------------------------------------------------
 
 const { mockUsePostsList } = vi.hoisted(() => {
-	const mockUsePostsList = vi.fn()
+	const mockUsePostsList = vi.fn();
 
-	return { mockUsePostsList }
-})
+	return { mockUsePostsList };
+});
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -31,45 +31,45 @@ const { mockUsePostsList } = vi.hoisted(() => {
 
 vi.mock("@/features/posts/hooks/usePostsList", () => ({
 	usePostsList: mockUsePostsList,
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { PostsListPage } from "./PostsListPage"
+import { PostsListPage } from "./PostsListPage";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 interface MockHookState {
-	posts: PostListResponse["posts"] | undefined
-	total: number | undefined
-	isLoading: boolean
-	isError: boolean
+	posts: PostListResponse["posts"] | undefined;
+	total: number | undefined;
+	isLoading: boolean;
+	isError: boolean;
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-let root: Root | undefined
-let container: HTMLDivElement | undefined
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
 
 function mountPostsListPage(): HTMLDivElement {
-	container = document.createElement("div")
-	document.body.append(container)
+	container = document.createElement("div");
+	document.body.append(container);
 	act(() => {
-		root = createRoot(container as HTMLDivElement)
-		root.render(<PostsListPage />)
-	})
+		root = createRoot(container as HTMLDivElement);
+		root.render(<PostsListPage />);
+	});
 
-	return container
+	return container;
 }
 
 function setMockState(state: MockHookState): void {
-	mockUsePostsList.mockReturnValue(state)
+	mockUsePostsList.mockReturnValue(state);
 }
 
 // ---------------------------------------------------------------------------
@@ -77,17 +77,19 @@ function setMockState(state: MockHookState): void {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	setMockState({ posts: [], total: 0, isLoading: false, isError: false })
-})
+	setMockState({ posts: [], total: 0, isLoading: false, isError: false });
+});
 
 afterEach(() => {
 	if (root) {
-		act(() => { root?.unmount() })
-		root = undefined
+		act(() => {
+			root?.unmount();
+		});
+		root = undefined;
 	}
-	container?.remove()
-	container = undefined
-})
+	container?.remove();
+	container = undefined;
+});
 
 // ---------------------------------------------------------------------------
 // Tests — rendering
@@ -95,15 +97,15 @@ afterEach(() => {
 
 describe("PostsListPage — rendering", () => {
 	it("renders a heading containing 'Posts'", () => {
-		const el = mountPostsListPage()
-		expect(el.textContent).toContain("Posts")
-	})
+		const el = mountPostsListPage();
+		expect(el.textContent).toContain("Posts");
+	});
 
 	it("shows empty state message when posts is an empty array", () => {
-		setMockState({ posts: [], total: 0, isLoading: false, isError: false })
-		const el = mountPostsListPage()
-		expect(el.textContent).toContain("No posts yet")
-	})
+		setMockState({ posts: [], total: 0, isLoading: false, isError: false });
+		const el = mountPostsListPage();
+		expect(el.textContent).toContain("No posts yet");
+	});
 
 	it("renders post content when posts are returned", () => {
 		setMockState({
@@ -118,10 +120,10 @@ describe("PostsListPage — rendering", () => {
 			total: 1,
 			isLoading: false,
 			isError: false,
-		})
-		const el = mountPostsListPage()
-		expect(el.textContent).toContain("Hello from a post")
-	})
+		});
+		const el = mountPostsListPage();
+		expect(el.textContent).toContain("Hello from a post");
+	});
 
 	it("renders multiple posts", () => {
 		setMockState({
@@ -142,12 +144,12 @@ describe("PostsListPage — rendering", () => {
 			total: 2,
 			isLoading: false,
 			isError: false,
-		})
-		const el = mountPostsListPage()
-		expect(el.textContent).toContain("First post")
-		expect(el.textContent).toContain("Second post")
-	})
-})
+		});
+		const el = mountPostsListPage();
+		expect(el.textContent).toContain("First post");
+		expect(el.textContent).toContain("Second post");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — loading state
@@ -155,19 +157,29 @@ describe("PostsListPage — rendering", () => {
 
 describe("PostsListPage — loading state", () => {
 	it("renders a loading status element while loading", () => {
-		setMockState({ posts: undefined, total: undefined, isLoading: true, isError: false })
-		const el = mountPostsListPage()
-		const status = el.querySelector("[role='status']")
-		expect(status).not.toBeNull()
-		expect(el.textContent).toContain("Loading")
-	})
+		setMockState({
+			posts: undefined,
+			total: undefined,
+			isLoading: true,
+			isError: false,
+		});
+		const el = mountPostsListPage();
+		const status = el.querySelector("[role='status']");
+		expect(status).not.toBeNull();
+		expect(el.textContent).toContain("Loading");
+	});
 
 	it("does not show empty state message while loading", () => {
-		setMockState({ posts: undefined, total: undefined, isLoading: true, isError: false })
-		const el = mountPostsListPage()
-		expect(el.textContent).not.toContain("No posts yet")
-	})
-})
+		setMockState({
+			posts: undefined,
+			total: undefined,
+			isLoading: true,
+			isError: false,
+		});
+		const el = mountPostsListPage();
+		expect(el.textContent).not.toContain("No posts yet");
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — error state
@@ -175,22 +187,37 @@ describe("PostsListPage — loading state", () => {
 
 describe("PostsListPage — error state", () => {
 	it("renders an alert element when isError is true", () => {
-		setMockState({ posts: undefined, total: undefined, isLoading: false, isError: true })
-		const el = mountPostsListPage()
-		const alert = el.querySelector("[role='alert']")
-		expect(alert).not.toBeNull()
-	})
+		setMockState({
+			posts: undefined,
+			total: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		const el = mountPostsListPage();
+		const alert = el.querySelector("[role='alert']");
+		expect(alert).not.toBeNull();
+	});
 
 	it("renders error message text when isError is true", () => {
-		setMockState({ posts: undefined, total: undefined, isLoading: false, isError: true })
-		const el = mountPostsListPage()
-		expect(el.textContent).toContain("Failed to load posts. Please try again.")
-	})
+		setMockState({
+			posts: undefined,
+			total: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		const el = mountPostsListPage();
+		expect(el.textContent).toContain("Failed to load posts. Please try again.");
+	});
 
 	it("does not show post list or empty state when isError is true", () => {
-		setMockState({ posts: undefined, total: undefined, isLoading: false, isError: true })
-		const el = mountPostsListPage()
-		expect(el.textContent).not.toContain("No posts yet")
-		expect(el.querySelector("ul")).toBeNull()
-	})
-})
+		setMockState({
+			posts: undefined,
+			total: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		const el = mountPostsListPage();
+		expect(el.textContent).not.toContain("No posts yet");
+		expect(el.querySelector("ul")).toBeNull();
+	});
+});

--- a/apps/react-frontend/src/features/posts/pages/PostsListPage.tsx
+++ b/apps/react-frontend/src/features/posts/pages/PostsListPage.tsx
@@ -1,10 +1,10 @@
-import { Heading, List, ListItem, Typography } from "@repo/ui"
-import { useTranslation } from "react-i18next"
-import { usePostsList } from "@/features/posts/hooks/usePostsList"
+import { Heading, List, ListItem, Typography } from "@repo/ui";
+import { useTranslation } from "react-i18next";
+import { usePostsList } from "@/features/posts/hooks/usePostsList";
 
 export function PostsListPage() {
-	const { t } = useTranslation()
-	const { posts, isLoading, isError } = usePostsList()
+	const { t } = useTranslation();
+	const { posts, isLoading, isError } = usePostsList();
 
 	return (
 		<main className="page-wrap px-4 py-12">
@@ -23,9 +23,12 @@ export function PostsListPage() {
 					</Typography>
 				)}
 
-				{!isLoading && !isError && posts !== undefined && posts.length === 0 && (
-					<Typography variant="muted">{t("posts.list.empty")}</Typography>
-				)}
+				{!isLoading &&
+					!isError &&
+					posts !== undefined &&
+					posts.length === 0 && (
+						<Typography variant="muted">{t("posts.list.empty")}</Typography>
+					)}
 
 				{!isLoading && !isError && posts !== undefined && posts.length > 0 && (
 					<List>
@@ -38,5 +41,5 @@ export function PostsListPage() {
 				)}
 			</div>
 		</main>
-	)
+	);
 }

--- a/apps/react-frontend/src/global.d.ts
+++ b/apps/react-frontend/src/global.d.ts
@@ -1,5 +1,5 @@
 declare global {
-	var IS_REACT_ACT_ENVIRONMENT: boolean
+	var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 
-export {}
+export {};

--- a/apps/react-frontend/src/locales/en.json
+++ b/apps/react-frontend/src/locales/en.json
@@ -1,76 +1,76 @@
 {
-  "signup": {
-    "title": "Create account",
-    "name": {
-      "label": "Name",
-      "placeholder": "Your name"
-    },
-    "email": {
-      "label": "Email",
-      "placeholder": "you@example.com"
-    },
-    "password": {
-      "label": "Password",
-      "placeholder": "Password"
-    },
-    "submit": "Sign up",
-    "submitting": "Signing up…",
-    "error": {
-      "emailAlreadyRegistered": "Email already registered",
-      "generic": "Signup failed. Please try again."
-    },
-    "validation": {
-      "nameRequired": "Name is required",
-      "emailRequired": "Email is required",
-      "emailInvalid": "Invalid email address",
-      "passwordRequired": "Password is required"
-    }
-  },
-  "posts": {
-    "list": {
-      "title": "Posts",
-      "empty": "No posts yet",
-      "loading": "Loading posts…",
-      "error": {
-        "generic": "Failed to load posts. Please try again."
-      }
-    },
-    "new": {
-      "title": "New Post",
-      "label": "Content",
-      "submit": "Post",
-      "charCount": "{{current}} / {{max}}",
-      "success": "Post created successfully",
-      "validation": {
-        "contentRequired": "Content is required",
-        "contentTooLong": "Content must be 280 characters or less"
-      },
-      "error": {
-        "generic": "Failed to create post. Please try again."
-      }
-    }
-  },
-  "login": {
-    "title": "Sign in",
-    "email": {
-      "label": "Email",
-      "placeholder": "you@example.com"
-    },
-    "password": {
-      "label": "Password",
-      "placeholder": "Password"
-    },
-    "submit": "Sign in",
-    "submitting": "Signing in…",
-    "error": {
-      "invalidCredentials": "Invalid email or password",
-      "generic": "Login failed. Please try again."
-    },
-    "validation": {
-      "emailRequired": "Email is required",
-      "emailInvalid": "Invalid email address",
-      "passwordRequired": "Password is required"
-    },
-    "signupLink": "Don't have an account? Sign up"
-  }
+	"signup": {
+		"title": "Create account",
+		"name": {
+			"label": "Name",
+			"placeholder": "Your name"
+		},
+		"email": {
+			"label": "Email",
+			"placeholder": "you@example.com"
+		},
+		"password": {
+			"label": "Password",
+			"placeholder": "Password"
+		},
+		"submit": "Sign up",
+		"submitting": "Signing up…",
+		"error": {
+			"emailAlreadyRegistered": "Email already registered",
+			"generic": "Signup failed. Please try again."
+		},
+		"validation": {
+			"nameRequired": "Name is required",
+			"emailRequired": "Email is required",
+			"emailInvalid": "Invalid email address",
+			"passwordRequired": "Password is required"
+		}
+	},
+	"posts": {
+		"list": {
+			"title": "Posts",
+			"empty": "No posts yet",
+			"loading": "Loading posts…",
+			"error": {
+				"generic": "Failed to load posts. Please try again."
+			}
+		},
+		"new": {
+			"title": "New Post",
+			"label": "Content",
+			"submit": "Post",
+			"charCount": "{{current}} / {{max}}",
+			"success": "Post created successfully",
+			"validation": {
+				"contentRequired": "Content is required",
+				"contentTooLong": "Content must be 280 characters or less"
+			},
+			"error": {
+				"generic": "Failed to create post. Please try again."
+			}
+		}
+	},
+	"login": {
+		"title": "Sign in",
+		"email": {
+			"label": "Email",
+			"placeholder": "you@example.com"
+		},
+		"password": {
+			"label": "Password",
+			"placeholder": "Password"
+		},
+		"submit": "Sign in",
+		"submitting": "Signing in…",
+		"error": {
+			"invalidCredentials": "Invalid email or password",
+			"generic": "Login failed. Please try again."
+		},
+		"validation": {
+			"emailRequired": "Email is required",
+			"emailInvalid": "Invalid email address",
+			"passwordRequired": "Password is required"
+		},
+		"signupLink": "Don't have an account? Sign up"
+	}
 }

--- a/apps/react-frontend/src/locales/ja.json
+++ b/apps/react-frontend/src/locales/ja.json
@@ -1,68 +1,68 @@
 {
-  "signup": {
-    "title": "アカウント作成",
-    "name": {
-      "label": "名前",
-      "placeholder": "お名前"
-    },
-    "email": {
-      "label": "メールアドレス",
-      "placeholder": "your@email.com"
-    },
-    "password": {
-      "label": "パスワード",
-      "placeholder": "パスワード"
-    },
-    "submit": "登録する",
-    "submitting": "登録中…",
-    "error": {
-      "emailAlreadyRegistered": "このメールアドレスはすでに登録されています",
-      "generic": "登録に失敗しました。もう一度お試しください。"
-    },
-    "validation": {
-      "nameRequired": "名前を入力してください",
-      "emailRequired": "メールアドレスを入力してください",
-      "emailInvalid": "有効なメールアドレスを入力してください",
-      "passwordRequired": "パスワードを入力してください"
-    }
-  },
-  "posts": {
-    "new": {
-      "title": "新規投稿",
-      "label": "内容",
-      "submit": "投稿する",
-      "charCount": "{{current}} / {{max}}",
-      "success": "投稿しました",
-      "validation": {
-        "contentRequired": "内容を入力してください",
-        "contentTooLong": "内容は280文字以内で入力してください"
-      },
-      "error": {
-        "generic": "投稿に失敗しました。もう一度お試しください。"
-      }
-    }
-  },
-  "login": {
-    "title": "ログイン",
-    "email": {
-      "label": "メールアドレス",
-      "placeholder": "your@email.com"
-    },
-    "password": {
-      "label": "パスワード",
-      "placeholder": "パスワード"
-    },
-    "submit": "ログイン",
-    "submitting": "ログイン中…",
-    "error": {
-      "invalidCredentials": "メールアドレスまたはパスワードが正しくありません",
-      "generic": "ログインに失敗しました。もう一度お試しください。"
-    },
-    "validation": {
-      "emailRequired": "メールアドレスを入力してください",
-      "emailInvalid": "有効なメールアドレスを入力してください",
-      "passwordRequired": "パスワードを入力してください"
-    },
-    "signupLink": "アカウントをお持ちでない方はこちら"
-  }
+	"signup": {
+		"title": "アカウント作成",
+		"name": {
+			"label": "名前",
+			"placeholder": "お名前"
+		},
+		"email": {
+			"label": "メールアドレス",
+			"placeholder": "your@email.com"
+		},
+		"password": {
+			"label": "パスワード",
+			"placeholder": "パスワード"
+		},
+		"submit": "登録する",
+		"submitting": "登録中…",
+		"error": {
+			"emailAlreadyRegistered": "このメールアドレスはすでに登録されています",
+			"generic": "登録に失敗しました。もう一度お試しください。"
+		},
+		"validation": {
+			"nameRequired": "名前を入力してください",
+			"emailRequired": "メールアドレスを入力してください",
+			"emailInvalid": "有効なメールアドレスを入力してください",
+			"passwordRequired": "パスワードを入力してください"
+		}
+	},
+	"posts": {
+		"new": {
+			"title": "新規投稿",
+			"label": "内容",
+			"submit": "投稿する",
+			"charCount": "{{current}} / {{max}}",
+			"success": "投稿しました",
+			"validation": {
+				"contentRequired": "内容を入力してください",
+				"contentTooLong": "内容は280文字以内で入力してください"
+			},
+			"error": {
+				"generic": "投稿に失敗しました。もう一度お試しください。"
+			}
+		}
+	},
+	"login": {
+		"title": "ログイン",
+		"email": {
+			"label": "メールアドレス",
+			"placeholder": "your@email.com"
+		},
+		"password": {
+			"label": "パスワード",
+			"placeholder": "パスワード"
+		},
+		"submit": "ログイン",
+		"submitting": "ログイン中…",
+		"error": {
+			"invalidCredentials": "メールアドレスまたはパスワードが正しくありません",
+			"generic": "ログインに失敗しました。もう一度お試しください。"
+		},
+		"validation": {
+			"emailRequired": "メールアドレスを入力してください",
+			"emailInvalid": "有効なメールアドレスを入力してください",
+			"passwordRequired": "パスワードを入力してください"
+		},
+		"signupLink": "アカウントをお持ちでない方はこちら"
+	}
 }

--- a/apps/react-frontend/src/main.tsx
+++ b/apps/react-frontend/src/main.tsx
@@ -1,17 +1,17 @@
-import { RouterProvider } from '@tanstack/react-router'
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import '@/utils/i18n'
-import { getRouter } from '@/router'
-import './styles.css'
+import { RouterProvider } from "@tanstack/react-router";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@/utils/i18n";
+import { getRouter } from "@/router";
+import "./styles.css";
 
-const router = getRouter()
+const router = getRouter();
 
-const rootElement = document.querySelector('#root')
-if (!rootElement) throw new Error('Root element not found')
+const rootElement = document.querySelector("#root");
+if (!rootElement) throw new Error("Root element not found");
 
 createRoot(rootElement).render(
-  <StrictMode>
-    <RouterProvider router={router} />
-  </StrictMode>,
-)
+	<StrictMode>
+		<RouterProvider router={router} />
+	</StrictMode>,
+);

--- a/apps/react-frontend/src/router.tsx
+++ b/apps/react-frontend/src/router.tsx
@@ -1,20 +1,20 @@
-import { createRouter as createTanStackRouter } from '@tanstack/react-router'
-import { routeTree } from './routeTree.gen'
+import { createRouter as createTanStackRouter } from "@tanstack/react-router";
+import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
-  const router = createTanStackRouter({
-    routeTree,
+	const router = createTanStackRouter({
+		routeTree,
 
-    scrollRestoration: true,
-    defaultPreload: 'intent',
-    defaultPreloadStaleTime: 0,
-  })
+		scrollRestoration: true,
+		defaultPreload: "intent",
+		defaultPreloadStaleTime: 0,
+	});
 
-  return router
+	return router;
 }
 
-declare module '@tanstack/react-router' {
-  interface Register {
-    router: ReturnType<typeof getRouter>
-  }
+declare module "@tanstack/react-router" {
+	interface Register {
+		router: ReturnType<typeof getRouter>;
+	}
 }

--- a/apps/react-frontend/src/routes/__root.tsx
+++ b/apps/react-frontend/src/routes/__root.tsx
@@ -1,16 +1,16 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { Outlet, createRootRoute } from "@tanstack/react-router"
-import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
-import { useState } from "react"
-import { Toaster } from "@repo/ui"
-import { AuthProvider } from "@/features/auth/contexts/AuthContext"
+import { Toaster } from "@repo/ui";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { useState } from "react";
+import { AuthProvider } from "@/features/auth/contexts/AuthContext";
 
 export const Route = createRootRoute({
 	component: RootLayout,
-})
+});
 
 function RootLayout() {
-	const [queryClient] = useState(() => new QueryClient())
+	const [queryClient] = useState(() => new QueryClient());
 
 	return (
 		<QueryClientProvider client={queryClient}>
@@ -22,5 +22,5 @@ function RootLayout() {
 				</div>
 			</AuthProvider>
 		</QueryClientProvider>
-	)
+	);
 }

--- a/apps/react-frontend/src/routes/_auth.test.tsx
+++ b/apps/react-frontend/src/routes/_auth.test.tsx
@@ -8,45 +8,45 @@
  *  - @tanstack/react-router   Outlet vi.mock
  */
 
-import React, { act } from "react"
-import { createRoot } from "react-dom/client"
-import type { Root } from "react-dom/client"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import React, { act } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
 // ---------------------------------------------------------------------------
 
 function routeOptions(options: { component: unknown }) {
-	return options
+	return options;
 }
 
 vi.mock("@tanstack/react-router", () => ({
 	Outlet: () => React.createElement("div", { "data-testid": "outlet" }),
 	createFileRoute: () => routeOptions,
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { AuthLayout } from "./_auth"
+import { AuthLayout } from "./_auth";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-let root: Root | null = null
-let container: HTMLDivElement | null = null
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
 
 async function mount(): Promise<void> {
-	const div = document.createElement("div")
-	document.body.append(div)
-	container = div
+	const div = document.createElement("div");
+	document.body.append(div);
+	container = div;
 	await act(async () => {
-		root = createRoot(div)
-		root.render(<AuthLayout />)
-	})
+		root = createRoot(div);
+		root.render(<AuthLayout />);
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -55,15 +55,15 @@ async function mount(): Promise<void> {
 
 afterEach(async () => {
 	if (root) {
-		const r = root
-		root = null
+		const r = root;
+		root = null;
 		await act(async () => {
-			r.unmount()
-		})
+			r.unmount();
+		});
 	}
-	container?.remove()
-	container = null
-})
+	container?.remove();
+	container = null;
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -71,17 +71,17 @@ afterEach(async () => {
 
 describe("AuthLayout — rendering", () => {
 	it("renders the router Outlet placeholder", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='outlet']")).not.toBeNull()
-	})
+		await mount();
+		expect(document.querySelector("[data-testid='outlet']")).not.toBeNull();
+	});
 
 	it("does NOT render the Header component", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='header']")).toBeNull()
-	})
+		await mount();
+		expect(document.querySelector("[data-testid='header']")).toBeNull();
+	});
 
 	it("does NOT render the Footer component", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='footer']")).toBeNull()
-	})
-})
+		await mount();
+		expect(document.querySelector("[data-testid='footer']")).toBeNull();
+	});
+});

--- a/apps/react-frontend/src/routes/_auth.tsx
+++ b/apps/react-frontend/src/routes/_auth.tsx
@@ -1,11 +1,11 @@
-import { Outlet, createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_auth")({
 	component: AuthLayout,
-})
+});
 
 export function AuthLayout() {
 	// Minimal pass-through: auth pages (login, signup) need no chrome.
 	// A future authentication guard (beforeLoad redirect) will be added here in a separate issue.
-	return <Outlet />
+	return <Outlet />;
 }

--- a/apps/react-frontend/src/routes/_auth/login.tsx
+++ b/apps/react-frontend/src/routes/_auth/login.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { LoginPage } from "@/features/auth/pages/LoginPage"
+import { createFileRoute } from "@tanstack/react-router";
+import { LoginPage } from "@/features/auth/pages/LoginPage";
 
 export const Route = createFileRoute("/_auth/login")({
 	component: LoginPage,
-})
+});

--- a/apps/react-frontend/src/routes/_auth/signup.tsx
+++ b/apps/react-frontend/src/routes/_auth/signup.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { SignupPage } from "@/features/auth/pages/SignupPage"
+import { createFileRoute } from "@tanstack/react-router";
+import { SignupPage } from "@/features/auth/pages/SignupPage";
 
 export const Route = createFileRoute("/_auth/signup")({
 	component: SignupPage,
-})
+});

--- a/apps/react-frontend/src/routes/_authenticated.test.tsx
+++ b/apps/react-frontend/src/routes/_authenticated.test.tsx
@@ -13,10 +13,10 @@
  *  - @/utils/tokenStorage     getToken                              vi.mock
  */
 
-import React, { act } from "react"
-import { createRoot } from "react-dom/client"
-import type { Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React, { act } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock functions (must be defined before vi.mock calls)
@@ -26,14 +26,14 @@ const { mockGetToken, mockRedirectResult } = vi.hoisted(() => ({
 	mockGetToken: vi.fn<() => string | null>(),
 	// redirect() returns a sentinel object; the beforeLoad guard throws it
 	mockRedirectResult: { __isRedirect: true, to: "/login" },
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
 // ---------------------------------------------------------------------------
 
 function passThrough(options: Record<string, unknown>) {
-	return options
+	return options;
 }
 
 // Pass the full route config through so both `component` and `beforeLoad` are
@@ -42,32 +42,32 @@ vi.mock("@tanstack/react-router", () => ({
 	Outlet: () => React.createElement("div", { "data-testid": "outlet" }),
 	createFileRoute: () => passThrough,
 	redirect: vi.fn(() => mockRedirectResult),
-}))
+}));
 
 vi.mock("@/components/Header", () => ({
 	default: () => React.createElement("header", { "data-testid": "header" }),
-}))
+}));
 
 vi.mock("@/components/Footer", () => ({
 	default: () => React.createElement("footer", { "data-testid": "footer" }),
-}))
+}));
 
 vi.mock("@/utils/tokenStorage", () => ({
 	getToken: mockGetToken,
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { redirect } from "@tanstack/react-router"
-import { AuthenticatedLayout, Route } from "./_authenticated"
+import { redirect } from "@tanstack/react-router";
+import { AuthenticatedLayout, Route } from "./_authenticated";
 
 // ---------------------------------------------------------------------------
 // Typed mock references
 // ---------------------------------------------------------------------------
 
-const mockRedirect = redirect as ReturnType<typeof vi.fn>
+const mockRedirect = redirect as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Extract beforeLoad from the Route config
@@ -76,25 +76,25 @@ const mockRedirect = redirect as ReturnType<typeof vi.fn>
 // With the mock in place, Route is the raw config object passed to
 // createFileRoute(...)({...}), so beforeLoad is directly accessible.
 const { beforeLoad } = Route as unknown as {
-	beforeLoad: () => void
-	component: React.ComponentType
-}
+	beforeLoad: () => void;
+	component: React.ComponentType;
+};
 
 // ---------------------------------------------------------------------------
 // Helpers — component rendering
 // ---------------------------------------------------------------------------
 
-let root: Root | null = null
-let container: HTMLDivElement | null = null
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
 
 async function mount(): Promise<void> {
-	const div = document.createElement("div")
-	document.body.append(div)
-	container = div
+	const div = document.createElement("div");
+	document.body.append(div);
+	container = div;
 	await act(async () => {
-		root = createRoot(div)
-		root.render(<AuthenticatedLayout />)
-	})
+		root = createRoot(div);
+		root.render(<AuthenticatedLayout />);
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -103,25 +103,25 @@ async function mount(): Promise<void> {
 
 afterEach(async () => {
 	if (root) {
-		const r = root
-		root = null
+		const r = root;
+		root = null;
 		await act(async () => {
-			r.unmount()
-		})
+			r.unmount();
+		});
 	}
-	container?.remove()
-	container = null
-})
+	container?.remove();
+	container = null;
+});
 
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-	mockGetToken.mockReset()
-	mockRedirect.mockReset()
-	mockRedirect.mockReturnValue(mockRedirectResult)
-})
+	mockGetToken.mockReset();
+	mockRedirect.mockReset();
+	mockRedirect.mockReturnValue(mockRedirectResult);
+});
 
 // ---------------------------------------------------------------------------
 // Tests — component rendering
@@ -129,20 +129,20 @@ beforeEach(() => {
 
 describe("AuthenticatedLayout — rendering", () => {
 	it("renders the Header component", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='header']")).not.toBeNull()
-	})
+		await mount();
+		expect(document.querySelector("[data-testid='header']")).not.toBeNull();
+	});
 
 	it("renders the Footer component", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='footer']")).not.toBeNull()
-	})
+		await mount();
+		expect(document.querySelector("[data-testid='footer']")).not.toBeNull();
+	});
 
 	it("renders the router Outlet placeholder", async () => {
-		await mount()
-		expect(document.querySelector("[data-testid='outlet']")).not.toBeNull()
-	})
-})
+		await mount();
+		expect(document.querySelector("[data-testid='outlet']")).not.toBeNull();
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests — beforeLoad guard
@@ -150,24 +150,24 @@ describe("AuthenticatedLayout — rendering", () => {
 
 describe("_authenticated — beforeLoad guard", () => {
 	it("does not throw when getToken returns a non-null token", () => {
-		mockGetToken.mockReturnValue("valid-jwt-token")
+		mockGetToken.mockReturnValue("valid-jwt-token");
 
-		expect(() => beforeLoad()).not.toThrow()
-	})
+		expect(() => beforeLoad()).not.toThrow();
+	});
 
 	it("throws a redirect to /login when getToken returns null", () => {
-		mockGetToken.mockReturnValue(null)
+		mockGetToken.mockReturnValue(null);
 
-		let thrown: unknown
+		let thrown: unknown;
 		try {
-			beforeLoad()
+			beforeLoad();
 		} catch (error) {
-			thrown = error
+			thrown = error;
 		}
 
 		// The guard must throw — and what it throws must be the redirect sentinel
-		expect(thrown).toBeDefined()
-		expect(thrown).toBe(mockRedirectResult)
-		expect(mockRedirect).toHaveBeenCalledWith({ to: "/login" })
-	})
-})
+		expect(thrown).toBeDefined();
+		expect(thrown).toBe(mockRedirectResult);
+		expect(mockRedirect).toHaveBeenCalledWith({ to: "/login" });
+	});
+});

--- a/apps/react-frontend/src/routes/_authenticated.tsx
+++ b/apps/react-frontend/src/routes/_authenticated.tsx
@@ -1,16 +1,16 @@
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router"
-import Footer from "@/components/Footer"
-import Header from "@/components/Header"
-import { getToken } from "@/utils/tokenStorage"
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import Footer from "@/components/Footer";
+import Header from "@/components/Header";
+import { getToken } from "@/utils/tokenStorage";
 
 export const Route = createFileRoute("/_authenticated")({
 	beforeLoad: () => {
 		if (!getToken()) {
-			throw redirect({ to: "/login" })
+			throw redirect({ to: "/login" });
 		}
 	},
 	component: AuthenticatedLayout,
-})
+});
 
 export function AuthenticatedLayout() {
 	return (
@@ -19,5 +19,5 @@ export function AuthenticatedLayout() {
 			<Outlet />
 			<Footer />
 		</>
-	)
+	);
 }

--- a/apps/react-frontend/src/routes/_authenticated/index.tsx
+++ b/apps/react-frontend/src/routes/_authenticated/index.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { HomePage } from "@/features/home/pages/HomePage"
+import { createFileRoute } from "@tanstack/react-router";
+import { HomePage } from "@/features/home/pages/HomePage";
 
 export const Route = createFileRoute("/_authenticated/")({
 	component: HomePage,
-})
+});

--- a/apps/react-frontend/src/routes/_authenticated/posts/index.tsx
+++ b/apps/react-frontend/src/routes/_authenticated/posts/index.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { PostsListPage } from "@/features/posts/pages/PostsListPage"
+import { createFileRoute } from "@tanstack/react-router";
+import { PostsListPage } from "@/features/posts/pages/PostsListPage";
 
 export const Route = createFileRoute("/_authenticated/posts/")({
 	component: PostsListPage,
-})
+});

--- a/apps/react-frontend/src/routes/_authenticated/posts/new.tsx
+++ b/apps/react-frontend/src/routes/_authenticated/posts/new.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { NewPostPage } from "@/features/posts/pages/NewPostPage"
+import { createFileRoute } from "@tanstack/react-router";
+import { NewPostPage } from "@/features/posts/pages/NewPostPage";
 
 export const Route = createFileRoute("/_authenticated/posts/new")({
 	component: NewPostPage,
-})
+});

--- a/apps/react-frontend/src/test-setup.ts
+++ b/apps/react-frontend/src/test-setup.ts
@@ -1,20 +1,20 @@
 // Configure React's act() environment for jsdom tests
-globalThis.IS_REACT_ACT_ENVIRONMENT = true
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 // Initialize i18n with English for tests so assertions use English strings
-import i18n from 'i18next'
-import { initReactI18next } from 'react-i18next'
-import en from '@/locales/en.json'
-import ja from '@/locales/ja.json'
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "@/locales/en.json";
+import ja from "@/locales/ja.json";
 
 void i18n.use(initReactI18next).init({
-  resources: {
-    en: { translation: en },
-    ja: { translation: ja },
-  },
-  lng: 'en',
-  fallbackLng: 'en',
-  interpolation: { escapeValue: false },
-  // Suppress i18next promotional output during tests
-  partialBundledLanguages: true,
-})
+	resources: {
+		en: { translation: en },
+		ja: { translation: ja },
+	},
+	lng: "en",
+	fallbackLng: "en",
+	interpolation: { escapeValue: false },
+	// Suppress i18next promotional output during tests
+	partialBundledLanguages: true,
+});

--- a/apps/react-frontend/src/utils/i18n.ts
+++ b/apps/react-frontend/src/utils/i18n.ts
@@ -1,15 +1,14 @@
-import i18n from 'i18next'
-import { initReactI18next } from 'react-i18next'
-import en from '@/locales/en.json'
-import ja from '@/locales/ja.json'
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "@/locales/en.json";
+import ja from "@/locales/ja.json";
 
 void i18n.use(initReactI18next).init({
-  resources: {
-    en: { translation: en },
-    ja: { translation: ja },
-  },
-  lng: 'ja',
-  fallbackLng: 'en',
-  interpolation: { escapeValue: false },
-})
-
+	resources: {
+		en: { translation: en },
+		ja: { translation: ja },
+	},
+	lng: "ja",
+	fallbackLng: "en",
+	interpolation: { escapeValue: false },
+});

--- a/apps/react-frontend/src/utils/tokenStorage.test.ts
+++ b/apps/react-frontend/src/utils/tokenStorage.test.ts
@@ -1,15 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest"
-import {
-	getToken,
-	removeToken,
-	saveToken,
-} from "@/utils/tokenStorage"
+import { afterEach, describe, expect, it } from "vitest";
+import { getToken, removeToken, saveToken } from "@/utils/tokenStorage";
 
 // ---------------------------------------------------------------------------
 // The localStorage key the module is expected to use.
 // Keeping it here makes the intent explicit and guards against typos.
 // ---------------------------------------------------------------------------
-const AUTH_TOKEN_KEY = "auth_token"
+const AUTH_TOKEN_KEY = "auth_token";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -19,96 +15,96 @@ describe("tokenStorage", () => {
 	// Always start each test with a clean slate so tests do not bleed into
 	// each other regardless of execution order.
 	afterEach(() => {
-		localStorage.clear()
-	})
+		localStorage.clear();
+	});
 
 	// -------------------------------------------------------------------------
 	// saveToken
 	// -------------------------------------------------------------------------
 	describe("saveToken", () => {
 		it("stores the token in localStorage under the key 'auth_token'", () => {
-			saveToken("my-jwt")
+			saveToken("my-jwt");
 
-			expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe("my-jwt")
-		})
+			expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe("my-jwt");
+		});
 
 		const overwriteCases = [
 			{ name: "short token", first: "first-token", second: "second-token" },
 			{ name: "empty string token", first: "some-token", second: "" },
-		]
+		];
 
 		for (const { name, first, second } of overwriteCases) {
 			it(`overwrites a previously saved token — ${name}`, () => {
-				saveToken(first)
-				saveToken(second)
+				saveToken(first);
+				saveToken(second);
 
-				expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe(second)
-			})
+				expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe(second);
+			});
 		}
-	})
+	});
 
 	// -------------------------------------------------------------------------
 	// getToken
 	// -------------------------------------------------------------------------
 	describe("getToken", () => {
 		it("returns the token that was previously saved", () => {
-			localStorage.setItem(AUTH_TOKEN_KEY, "stored-jwt")
+			localStorage.setItem(AUTH_TOKEN_KEY, "stored-jwt");
 
-			expect(getToken()).toBe("stored-jwt")
-		})
+			expect(getToken()).toBe("stored-jwt");
+		});
 
 		it("returns null when no token has been saved", () => {
 			// localStorage starts empty thanks to afterEach
-			expect(getToken()).toBeNull()
-		})
+			expect(getToken()).toBeNull();
+		});
 
 		it("returns null after the token has been removed", () => {
-			localStorage.setItem(AUTH_TOKEN_KEY, "to-be-removed")
-			localStorage.removeItem(AUTH_TOKEN_KEY)
+			localStorage.setItem(AUTH_TOKEN_KEY, "to-be-removed");
+			localStorage.removeItem(AUTH_TOKEN_KEY);
 
-			expect(getToken()).toBeNull()
-		})
-	})
+			expect(getToken()).toBeNull();
+		});
+	});
 
 	// -------------------------------------------------------------------------
 	// removeToken
 	// -------------------------------------------------------------------------
 	describe("removeToken", () => {
 		it("removes an existing token so getToken returns null afterwards", () => {
-			saveToken("jwt-to-delete")
+			saveToken("jwt-to-delete");
 
-			removeToken()
+			removeToken();
 
-			expect(getToken()).toBeNull()
-		})
+			expect(getToken()).toBeNull();
+		});
 
 		it("does not throw when called with no token present", () => {
 			// Expect removeToken to be a safe no-op when nothing is stored
-			expect(() => removeToken()).not.toThrow()
-		})
+			expect(() => removeToken()).not.toThrow();
+		});
 
 		it("does not affect other keys in localStorage", () => {
-			localStorage.setItem("other_key", "other_value")
-			saveToken("jwt-to-delete")
+			localStorage.setItem("other_key", "other_value");
+			saveToken("jwt-to-delete");
 
-			removeToken()
+			removeToken();
 
-			expect(localStorage.getItem("other_key")).toBe("other_value")
-		})
-	})
+			expect(localStorage.getItem("other_key")).toBe("other_value");
+		});
+	});
 
 	// -------------------------------------------------------------------------
 	// Round-trip: save → get → remove → get
 	// -------------------------------------------------------------------------
 	describe("full lifecycle round-trip", () => {
 		it("save then get returns the saved token, remove then get returns null", () => {
-			const token = "round-trip-token"
+			const token = "round-trip-token";
 
-			saveToken(token)
-			expect(getToken()).toBe(token)
+			saveToken(token);
+			expect(getToken()).toBe(token);
 
-			removeToken()
-			expect(getToken()).toBeNull()
-		})
-	})
-})
+			removeToken();
+			expect(getToken()).toBeNull();
+		});
+	});
+});

--- a/apps/react-frontend/src/utils/tokenStorage.ts
+++ b/apps/react-frontend/src/utils/tokenStorage.ts
@@ -1,13 +1,13 @@
-const AUTH_TOKEN_KEY = "auth_token"
+const AUTH_TOKEN_KEY = "auth_token";
 
 export function saveToken(token: string): void {
-	localStorage.setItem(AUTH_TOKEN_KEY, token)
+	localStorage.setItem(AUTH_TOKEN_KEY, token);
 }
 
 export function getToken(): string | null {
-	return localStorage.getItem(AUTH_TOKEN_KEY)
+	return localStorage.getItem(AUTH_TOKEN_KEY);
 }
 
 export function removeToken(): void {
-	localStorage.removeItem(AUTH_TOKEN_KEY)
+	localStorage.removeItem(AUTH_TOKEN_KEY);
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,13 +1,12 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
 		"useIgnoreFile": false
 	},
 	"files": {
-		"ignoreUnknown": false,
-		"includes": ["**/*.ts"]
+		"ignoreUnknown": false
 	},
 	"formatter": {
 		"enabled": true,

--- a/e2e/biome.jsonc
+++ b/e2e/biome.jsonc
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+	"extends": ["../biome.jsonc"],
+	"files": {
+		"includes": ["**/*.ts"]
+	}
+}

--- a/eslint.config.base.mjs
+++ b/eslint.config.base.mjs
@@ -1,0 +1,27 @@
+/**
+ * ESLint base configuration shared across all workspaces.
+ *
+ * This config turns off formatting rules that Biome owns.
+ * Workspaces import this and spread it into their own config array.
+ *
+ * @example
+ * import { formattingRulesOff } from "../../eslint.config.base.mjs";
+ * export default tseslint.config(
+ *   // ... workspace-specific configs ...
+ *   formattingRulesOff,
+ * );
+ */
+
+/** Disable ESLint formatting rules that conflict with Biome. */
+export const formattingRulesOff = {
+	rules: {
+		indent: "off",
+		quotes: "off",
+		semi: "off",
+		"comma-dangle": "off",
+		"max-len": "off",
+		"object-curly-spacing": "off",
+		"arrow-parens": "off",
+		"space-before-function-paren": "off",
+	},
+};

--- a/packages/ui/biome.jsonc
+++ b/packages/ui/biome.jsonc
@@ -1,29 +1,8 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
-	"vcs": {
-		"enabled": false,
-		"clientKind": "git",
-		"useIgnoreFile": false
-	},
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+	"extends": ["../../biome.jsonc"],
 	"files": {
-		"ignoreUnknown": false,
 		"includes": ["**/src/**/*", "**/vite.config.ts"]
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab"
-	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double"
-		}
 	},
 	"css": {
 		"parser": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "typecheck": "tsc --noEmit",
-    "format": "biome format",
-    "lint": "biome lint",
+    "format": "biome check --write",
+    "lint": "biome check",
     "check": "biome check"
   },
   "dependencies": {
@@ -51,7 +51,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "pnpm biome lint --write"
+      "pnpm biome check --write"
     ]
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,9 +10,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "typecheck": "tsc --noEmit",
-    "format": "biome check --write",
-    "lint": "biome check",
-    "check": "biome check"
+    "format": "biome check --write src/*",
+    "lint": "biome check src/*"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "1.3.3",

--- a/packages/ui/src/components/Badge.tsx
+++ b/packages/ui/src/components/Badge.tsx
@@ -1,4 +1,4 @@
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type { ComponentProps } from "react";
 
 const badgeVariants = cva(
@@ -6,10 +6,8 @@ const badgeVariants = cva(
 	{
 		variants: {
 			variant: {
-				default:
-					"border-transparent bg-primary text-primary-foreground shadow",
-				secondary:
-					"border-transparent bg-secondary text-secondary-foreground",
+				default: "border-transparent bg-primary text-primary-foreground shadow",
+				secondary: "border-transparent bg-secondary text-secondary-foreground",
 				destructive:
 					"border-transparent bg-destructive text-destructive-foreground shadow",
 				outline: "text-foreground",

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type { ComponentProps } from "react";
 
 const buttonVariants = cva(

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -1,8 +1,6 @@
 import type { ComponentProps } from "react";
 
-function Card({
-	...props
-}: Omit<ComponentProps<"div">, "className">) {
+function Card({ ...props }: Omit<ComponentProps<"div">, "className">) {
 	return (
 		<div
 			className="rounded-xl border bg-card text-card-foreground shadow"
@@ -11,15 +9,11 @@ function Card({
 	);
 }
 
-function CardHeader({
-	...props
-}: Omit<ComponentProps<"div">, "className">) {
+function CardHeader({ ...props }: Omit<ComponentProps<"div">, "className">) {
 	return <div className="flex flex-col space-y-1.5 p-6" {...props} />;
 }
 
-function CardTitle({
-	...props
-}: Omit<ComponentProps<"div">, "className">) {
+function CardTitle({ ...props }: Omit<ComponentProps<"div">, "className">) {
 	return (
 		<div className="font-semibold leading-none tracking-tight" {...props} />
 	);
@@ -31,23 +25,19 @@ function CardDescription({
 	return <div className="text-sm text-muted-foreground" {...props} />;
 }
 
-function CardContent({
-	...props
-}: Omit<ComponentProps<"div">, "className">) {
+function CardContent({ ...props }: Omit<ComponentProps<"div">, "className">) {
 	return <div className="p-6 pt-0" {...props} />;
 }
 
-function CardFooter({
-	...props
-}: Omit<ComponentProps<"div">, "className">) {
+function CardFooter({ ...props }: Omit<ComponentProps<"div">, "className">) {
 	return <div className="flex items-center p-6 pt-0" {...props} />;
 }
 
 export {
 	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
 	CardHeader,
 	CardTitle,
-	CardDescription,
-	CardContent,
-	CardFooter,
 };

--- a/packages/ui/src/components/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Label } from "./Label";
 import { Checkbox } from "./Checkbox";
+import { Label } from "./Label";
 
 const meta = {
 	title: "Components/Checkbox",

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -96,13 +96,13 @@ function DialogDescription({ ...props }: DialogDescriptionProps) {
 
 export {
 	Dialog,
-	DialogPortal,
-	DialogOverlay,
-	DialogTrigger,
 	DialogClose,
 	DialogContent,
-	DialogHeader,
-	DialogFooter,
-	DialogTitle,
 	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTitle,
+	DialogTrigger,
 };

--- a/packages/ui/src/components/Form.tsx
+++ b/packages/ui/src/components/Form.tsx
@@ -1,13 +1,13 @@
 import { Root as LabelRoot } from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
-import { createContext, useContext, useId, type ComponentProps } from "react";
+import { type ComponentProps, createContext, useContext, useId } from "react";
 import {
 	Controller,
-	FormProvider,
-	useFormContext,
 	type ControllerProps,
 	type FieldPath,
 	type FieldValues,
+	FormProvider,
+	useFormContext,
 } from "react-hook-form";
 import { cn } from "../lib/utils";
 

--- a/packages/ui/src/components/Input.stories.tsx
+++ b/packages/ui/src/components/Input.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Label } from "./Label";
 import { Input } from "./Input";
+import { Label } from "./Label";
 
 const meta = {
 	title: "Components/Input",

--- a/packages/ui/src/components/Select.stories.tsx
+++ b/packages/ui/src/components/Select.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import {
 	Select,
 	SelectContent,
+	SelectGroup,
 	SelectItem,
 	SelectLabel,
-	SelectGroup,
 	SelectTrigger,
 	SelectValue,
 } from "./Select";

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -141,13 +141,13 @@ function SelectSeparator({ ...props }: SelectSeparatorProps) {
 
 export {
 	Select,
-	SelectGroup,
-	SelectValue,
-	SelectTrigger,
 	SelectContent,
-	SelectLabel,
+	SelectGroup,
 	SelectItem,
-	SelectSeparator,
-	SelectScrollUpButton,
+	SelectLabel,
 	SelectScrollDownButton,
+	SelectScrollUpButton,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
 };

--- a/packages/ui/src/components/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton.tsx
@@ -3,9 +3,7 @@ import type { ComponentProps } from "react";
 type SkeletonProps = Omit<ComponentProps<"div">, "className">;
 
 function Skeleton({ ...props }: SkeletonProps) {
-	return (
-		<div className="animate-pulse rounded-md bg-primary/10" {...props} />
-	);
+	return <div className="animate-pulse rounded-md bg-primary/10" {...props} />;
 }
 
 export { Skeleton };

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -45,4 +45,4 @@ function TabsContent({ ...props }: TabsContentProps) {
 	);
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/packages/ui/src/components/Toaster.tsx
+++ b/packages/ui/src/components/Toaster.tsx
@@ -1,2 +1,1 @@
-export { Toaster } from "sonner";
-export { toast } from "sonner";
+export { Toaster, toast } from "sonner";

--- a/packages/ui/src/components/Typography.stories.tsx
+++ b/packages/ui/src/components/Typography.stories.tsx
@@ -38,11 +38,21 @@ export const Blockquote: Story = {
 export const AllVariants: Story = {
 	render: () => (
 		<div className="flex flex-col gap-4">
-			<Typography variant="p">Paragraph: The quick brown fox jumps over the lazy dog.</Typography>
-			<Typography variant="lead">Lead: The quick brown fox jumps over the lazy dog.</Typography>
-			<Typography variant="muted">Muted: The quick brown fox jumps over the lazy dog.</Typography>
-			<Typography variant="small">Small: The quick brown fox jumps over the lazy dog.</Typography>
-			<Typography variant="blockquote">Blockquote: Design is not just what it looks like.</Typography>
+			<Typography variant="p">
+				Paragraph: The quick brown fox jumps over the lazy dog.
+			</Typography>
+			<Typography variant="lead">
+				Lead: The quick brown fox jumps over the lazy dog.
+			</Typography>
+			<Typography variant="muted">
+				Muted: The quick brown fox jumps over the lazy dog.
+			</Typography>
+			<Typography variant="small">
+				Small: The quick brown fox jumps over the lazy dog.
+			</Typography>
+			<Typography variant="blockquote">
+				Blockquote: Design is not just what it looks like.
+			</Typography>
 		</div>
 	),
 };

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -4,59 +4,59 @@
    @theme (without inline) outputs these as CSS custom properties in :root,
    so var(--color-primary) etc. are always defined and utilities resolve correctly. */
 @theme {
-  --color-background: oklch(1 0 0);
-  --color-foreground: oklch(0.145 0 0);
-  --color-card: oklch(1 0 0);
-  --color-card-foreground: oklch(0.145 0 0);
-  --color-popover: oklch(1 0 0);
-  --color-popover-foreground: oklch(0.145 0 0);
-  --color-primary: oklch(0.205 0 0);
-  --color-primary-foreground: oklch(0.985 0 0);
-  --color-secondary: oklch(0.97 0 0);
-  --color-secondary-foreground: oklch(0.205 0 0);
-  --color-muted: oklch(0.97 0 0);
-  --color-muted-foreground: oklch(0.556 0 0);
-  --color-accent: oklch(0.97 0 0);
-  --color-accent-foreground: oklch(0.205 0 0);
-  --color-destructive: oklch(0.577 0.245 27.325);
-  --color-destructive-foreground: oklch(0.985 0 0);
-  --color-border: oklch(0.922 0 0);
-  --color-input: oklch(0.922 0 0);
-  --color-ring: oklch(0.708 0 0);
+	--color-background: oklch(1 0 0);
+	--color-foreground: oklch(0.145 0 0);
+	--color-card: oklch(1 0 0);
+	--color-card-foreground: oklch(0.145 0 0);
+	--color-popover: oklch(1 0 0);
+	--color-popover-foreground: oklch(0.145 0 0);
+	--color-primary: oklch(0.205 0 0);
+	--color-primary-foreground: oklch(0.985 0 0);
+	--color-secondary: oklch(0.97 0 0);
+	--color-secondary-foreground: oklch(0.205 0 0);
+	--color-muted: oklch(0.97 0 0);
+	--color-muted-foreground: oklch(0.556 0 0);
+	--color-accent: oklch(0.97 0 0);
+	--color-accent-foreground: oklch(0.205 0 0);
+	--color-destructive: oklch(0.577 0.245 27.325);
+	--color-destructive-foreground: oklch(0.985 0 0);
+	--color-border: oklch(0.922 0 0);
+	--color-input: oklch(0.922 0 0);
+	--color-ring: oklch(0.708 0 0);
 }
 
 /* Dark mode overrides — applied when .dark class is on a parent element */
 .dark {
-  --color-background: oklch(0.145 0 0);
-  --color-foreground: oklch(0.985 0 0);
-  --color-card: oklch(0.205 0 0);
-  --color-card-foreground: oklch(0.985 0 0);
-  --color-popover: oklch(0.205 0 0);
-  --color-popover-foreground: oklch(0.985 0 0);
-  --color-primary: oklch(0.985 0 0);
-  --color-primary-foreground: oklch(0.205 0 0);
-  --color-secondary: oklch(0.269 0 0);
-  --color-secondary-foreground: oklch(0.985 0 0);
-  --color-muted: oklch(0.269 0 0);
-  --color-muted-foreground: oklch(0.708 0 0);
-  --color-accent: oklch(0.269 0 0);
-  --color-accent-foreground: oklch(0.985 0 0);
-  --color-destructive: oklch(0.396 0.141 25.723);
-  --color-destructive-foreground: oklch(0.985 0 0);
-  --color-border: oklch(0.269 0 0);
-  --color-input: oklch(0.269 0 0);
-  --color-ring: oklch(0.439 0 0);
+	--color-background: oklch(0.145 0 0);
+	--color-foreground: oklch(0.985 0 0);
+	--color-card: oklch(0.205 0 0);
+	--color-card-foreground: oklch(0.985 0 0);
+	--color-popover: oklch(0.205 0 0);
+	--color-popover-foreground: oklch(0.985 0 0);
+	--color-primary: oklch(0.985 0 0);
+	--color-primary-foreground: oklch(0.205 0 0);
+	--color-secondary: oklch(0.269 0 0);
+	--color-secondary-foreground: oklch(0.985 0 0);
+	--color-muted: oklch(0.269 0 0);
+	--color-muted-foreground: oklch(0.708 0 0);
+	--color-accent: oklch(0.269 0 0);
+	--color-accent-foreground: oklch(0.985 0 0);
+	--color-destructive: oklch(0.396 0.141 25.723);
+	--color-destructive-foreground: oklch(0.985 0 0);
+	--color-border: oklch(0.269 0 0);
+	--color-input: oklch(0.269 0 0);
+	--color-ring: oklch(0.439 0 0);
 }
 
 * {
-  box-sizing: border-box;
-  border-color: var(--color-border);
+	box-sizing: border-box;
+	border-color: var(--color-border);
 }
 
 body {
-  margin: 0;
-  background-color: var(--color-background);
-  color: var(--color-foreground);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+	margin: 0;
+	background-color: var(--color-background);
+	color: var(--color-foreground);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,26 @@
 export { Badge, badgeVariants } from "./components/Badge";
-export { Toaster, toast } from "./components/Toaster";
+export { Button, buttonVariants } from "./components/Button";
+export {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "./components/Card";
+export { Checkbox } from "./components/Checkbox";
+export {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTitle,
+	DialogTrigger,
+} from "./components/Dialog";
 export {
 	Form,
 	FormControl,
@@ -11,16 +32,24 @@ export {
 	useFormField,
 } from "./components/Form";
 export { Heading } from "./components/Heading";
-export { List, ListItem } from "./components/List";
-export { Typography } from "./components/Typography";
-export { Button, buttonVariants } from "./components/Button";
-export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "./components/Card";
-export { Checkbox } from "./components/Checkbox";
-export { Dialog, DialogPortal, DialogOverlay, DialogTrigger, DialogClose, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription } from "./components/Dialog";
 export { Input } from "./components/Input";
 export { Label } from "./components/Label";
-export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectLabel, SelectItem, SelectSeparator, SelectScrollUpButton, SelectScrollDownButton } from "./components/Select";
+export { List, ListItem } from "./components/List";
+export {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectScrollDownButton,
+	SelectScrollUpButton,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
+} from "./components/Select";
 export { Separator } from "./components/Separator";
 export { Skeleton } from "./components/Skeleton";
-export { Tabs, TabsList, TabsTrigger, TabsContent } from "./components/Tabs";
+export { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/Tabs";
 export { Textarea } from "./components/Textarea";
+export { Toaster, toast } from "./components/Toaster";
+export { Typography } from "./components/Typography";


### PR DESCRIPTION
## 背景・目的

各ワークスペースが独立した Biome 設定を持ち、将来ワークスペースが増えた際に共通ルールの一貫性が保てない問題があった（#133）。  
ルートに共通設定を集約し、各ワークスペースが `extends` で継承できる構成に変更する。

## 変更内容

- リポジトリルートに `biome.jsonc` を新規作成し、共通設定（`indentStyle: tab`・`quoteStyle: double`・`organizeImports`・`recommended` ルール）を定義
- `e2e/biome.json` を `e2e/biome.jsonc` にリネームし、ルート設定を継承する形に変更（TS ファイル限定の `files.includes` のみ維持）
- `packages/ui/biome.jsonc` をルート設定を継承する形に更新（`css.parser` 設定のみ維持）
- `apps/react-frontend/biome.jsonc` をルート設定を継承する形に更新（ワークスペース固有の linter rules のみ維持）
- リポジトリルートに `eslint.config.base.mjs` を新規作成し、Biome と競合するフォーマット系ルール（`indent`・`quotes`・`semi` 等）の OFF を集約
- `apps/react-frontend/eslint.config.mjs` をルートの `formattingRulesOff` を import する形にリファクタ
- Biome スクリプトを統一: `lint` → `biome check`、`fmt/format` → `biome check --write`、`lint-staged` → `biome check --write`（`packages/ui`・`apps/react-frontend`）

## テスト実施結果

| 対象 | コマンド | 結果 |
|---|---|---|
| react-frontend | `pnpm test` | ✅ 113 tests passed (13 files) |
| react-frontend | `pnpm lint` | ⚠ biome check は既存の整形未適用エラー（61件・変更前から存在）で失敗。ESLint は全通過。エラー件数は変更前と同一で regression なし |

## 関連 issue

Closes #133

## ADR / ドキュメント更新

なし

## 破壊的変更

なし