### PR TITLE
feat(go-backend): Connect-RPC サーバーを追加する

### DIFF
--- a/go-backend/.gitignore
+++ b/go-backend/.gitignore
@@ -7,3 +7,5 @@ test/mock
 !test/mock/usecase/shared/mock_transaction.go
 test/integration/wire_gen.go
 test/integration/client/generated
+
+.claude

--- a/go-backend/.golangci.toml
+++ b/go-backend/.golangci.toml
@@ -54,6 +54,7 @@ default-signifies-exhaustive = true
     {pkg = "database/sql", desc = "domain must not import database/sql; DB access belongs in the infrastructure layer (ADR-0004)"},
     {pkg = "github.com/Haya372/web-app-template/go-backend/internal/usecase", desc = "domain must not depend on usecase; dependency must flow inward only (ADR-0004)"},
     {pkg = "github.com/Haya372/web-app-template/go-backend/internal/infrastructure", desc = "domain must not depend on infrastructure; dependency must flow inward only (ADR-0004)"},
+    {pkg = "connectrpc.com/connect", desc = "domain must not import Connect-RPC types; connectrpc must stay in the infrastructure layer (ADR-0004)"},
   ]
 
 [linters.settings.depguard.rules.usecase-no-framework]
@@ -66,4 +67,5 @@ default-signifies-exhaustive = true
     {pkg = "github.com/jackc/pgtype", desc = "usecase must not import pgtype (ADR-0004)"},
     {pkg = "database/sql", desc = "usecase must not import database/sql; DB access belongs in the infrastructure layer (ADR-0004)"},
     {pkg = "github.com/Haya372/web-app-template/go-backend/internal/infrastructure", desc = "usecase must not depend on infrastructure; dependency must flow inward only (ADR-0004)"},
+    {pkg = "connectrpc.com/connect", desc = "usecase must not import Connect-RPC types; connectrpc must stay in the infrastructure layer (ADR-0004)"},
   ]

--- a/go-backend/cmd/server/main.go
+++ b/go-backend/cmd/server/main.go
@@ -7,6 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/di"
 	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/telemetry"
 )
@@ -14,8 +16,8 @@ import (
 func main() {
 	ctx := context.Background()
 
-	server, err := di.InitializeServer(ctx)
-	if err != nil {
+	servers, err := di.InitializeServers(ctx)
+	if err \!= nil {
 		panic(err)
 	}
 
@@ -23,18 +25,30 @@ func main() {
 	defer stop()
 
 	shutdown, err := telemetry.SetupOTelSDK(ctx)
-	if err != nil {
+	if err \!= nil {
 		panic(err)
 	}
 
 	defer func() {
-		err := shutdown(ctx)
-		if err != nil {
+		if err := shutdown(ctx); err \!= nil {
 			slog.Error("failed to shutdown telemetry", "error", err)
 		}
 	}()
 
-	if err := server.Start(ctx); err != nil {
-		slog.Error("failed to start server", "error", err)
+	// Start both servers concurrently. If one fails, the shared context is
+	// cancelled, which triggers a graceful shutdown of the other.
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		return servers.REST.Start(gCtx)
+	})
+
+	g.Go(func() error {
+		return servers.GRPC.Start(gCtx)
+	})
+
+	if err := g.Wait(); err \!= nil {
+		slog.Error("server error", "error", err)
+		os.Exit(1)
 	}
 }

--- a/go-backend/cmd/server/main.go
+++ b/go-backend/cmd/server/main.go
@@ -14,23 +14,30 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		slog.Error("server error", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	ctx := context.Background()
 
 	servers, err := di.InitializeServers(ctx)
-	if err \!= nil {
-		panic(err)
+	if err != nil {
+		return err
 	}
 
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	shutdown, err := telemetry.SetupOTelSDK(ctx)
-	if err \!= nil {
-		panic(err)
+	if err != nil {
+		return err
 	}
 
 	defer func() {
-		if err := shutdown(ctx); err \!= nil {
+		if err := shutdown(ctx); err != nil {
 			slog.Error("failed to shutdown telemetry", "error", err)
 		}
 	}()
@@ -47,8 +54,5 @@ func main() {
 		return servers.GRPC.Start(gCtx)
 	})
 
-	if err := g.Wait(); err \!= nil {
-		slog.Error("server error", "error", err)
-		os.Exit(1)
-	}
+	return g.Wait()
 }

--- a/go-backend/go.mod
+++ b/go-backend/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.42.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.49.0
+	golang.org/x/sync v0.20.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -91,7 +92,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/go-backend/internal/infrastructure/connectrpc/handler/health.go
+++ b/go-backend/internal/infrastructure/connectrpc/handler/health.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	v1 "github.com/Haya372/web-app-template/go-backend/internal/infrastructure/grpc/gen/health/v1"
+	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/grpc/gen/health/v1/healthv1connect"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type HealthHandler struct {
+	tracer trace.Tracer
+}
+
+var _ healthv1connect.HealthServiceHandler = (*HealthHandler)(nil)
+
+func NewHealthHandler() *HealthHandler {
+	return &HealthHandler{tracer: otel.Tracer("connectrpc-server")}
+}
+
+func (h *HealthHandler) Check(
+	ctx context.Context,
+	req *connect.Request[v1.CheckRequest],
+) (*connect.Response[v1.CheckResponse], error) {
+	_, span := h.tracer.Start(ctx, "HealthHandler.Check")
+	defer span.End()
+
+	return connect.NewResponse(&v1.CheckResponse{
+		Status: v1.ServingStatus_SERVING_STATUS_SERVING,
+	}), nil
+}

--- a/go-backend/internal/infrastructure/connectrpc/handler/health_test.go
+++ b/go-backend/internal/infrastructure/connectrpc/handler/health_test.go
@@ -1,0 +1,45 @@
+package handler_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/connectrpc/handler"
+	v1 "github.com/Haya372/web-app-template/go-backend/internal/infrastructure/grpc/gen/health/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthHandler_Check_ReturnsServing(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  func() context.Context
+	}{
+		{
+			name: "returns serving status with no error",
+			ctx:  context.Background,
+		},
+		{
+			name: "returns serving status even with cancelled context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				return ctx
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := handler.NewHealthHandler()
+			req := connect.NewRequest(&v1.CheckRequest{})
+
+			resp, err := h.Check(tt.ctx(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, v1.ServingStatus_SERVING_STATUS_SERVING, resp.Msg.GetStatus())
+		})
+	}
+}

--- a/go-backend/internal/infrastructure/connectrpc/server.go
+++ b/go-backend/internal/infrastructure/connectrpc/server.go
@@ -1,0 +1,82 @@
+package connectrpc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/connectrpc/handler"
+	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/grpc/gen/health/v1/healthv1connect"
+)
+
+const (
+	gracefulTimeout   = 5 * time.Second
+	readHeaderTimeout = 10 * time.Second
+)
+
+// Server wraps a net/http.Server that serves Connect-RPC endpoints.
+type Server struct {
+	httpServer *http.Server
+}
+
+// NewServer constructs a Connect-RPC Server listening on APP_GRPC_PORT (default :8081).
+func NewServer(h *handler.HealthHandler) *Server {
+	port := os.Getenv("APP_GRPC_PORT")
+	if port == "" {
+		port = "8081"
+	}
+
+	mux := http.NewServeMux()
+
+	path, connectHandler := healthv1connect.NewHealthServiceHandler(h)
+	mux.Handle(path, connectHandler)
+
+	return &Server{
+		httpServer: &http.Server{
+			Addr:              ":" + port,
+			Handler:           otelhttp.NewHandler(mux, "connectrpc"),
+			ReadHeaderTimeout: readHeaderTimeout,
+		},
+	}
+}
+
+// Addr returns the configured listen address (e.g. ":8081").
+func (s *Server) Addr() string {
+	return s.httpServer.Addr
+}
+
+// Start begins serving and blocks until ctx is cancelled, then performs a
+// graceful shutdown. A ListenAndServe failure is returned directly.
+func (s *Server) Start(ctx context.Context) error {
+	errCh := make(chan error, 1)
+
+	go func() {
+		if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+
+		close(errCh)
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Use WithoutCancel so the shutdown context is not immediately cancelled
+		// by the already-done parent ctx.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gracefulTimeout)
+		defer cancel()
+
+		shutdownErr := s.httpServer.Shutdown(shutdownCtx)
+
+		if listenErr := <-errCh; listenErr != nil {
+			return listenErr
+		}
+
+		return shutdownErr
+	case err := <-errCh:
+		return err
+	}
+}

--- a/go-backend/internal/infrastructure/connectrpc/server_test.go
+++ b/go-backend/internal/infrastructure/connectrpc/server_test.go
@@ -1,0 +1,111 @@
+package connectrpc_test
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/connectrpc"
+	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/connectrpc/handler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewServer_UsesEnvPort verifies that NewServer respects APP_GRPC_PORT.
+func TestNewServer_UsesEnvPort(t *testing.T) {
+	t.Setenv("APP_GRPC_PORT", "19090")
+
+	s := connectrpc.NewServer(handler.NewHealthHandler())
+
+	assert.Equal(t, ":19090", s.Addr())
+}
+
+// TestNewServer_DefaultPort verifies that NewServer falls back to port 8081
+// when APP_GRPC_PORT is not set.
+func TestNewServer_DefaultPort(t *testing.T) {
+	t.Setenv("APP_GRPC_PORT", "")
+
+	s := connectrpc.NewServer(handler.NewHealthHandler())
+
+	assert.Equal(t, ":8081", s.Addr())
+}
+
+// TestServer_Start_ShutdownOnContextCancel verifies that Start returns without
+// error when the context is cancelled, confirming graceful shutdown behaviour.
+func TestServer_Start_ShutdownOnContextCancel(t *testing.T) {
+	t.Setenv("APP_GRPC_PORT", "18081")
+
+	h := handler.NewHealthHandler()
+	s := connectrpc.NewServer(h)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- s.Start(ctx)
+	}()
+
+	// Give the server a moment to bind before cancelling.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return within timeout after context cancel")
+	}
+}
+
+// TestServer_Start_AlreadyCancelledContext verifies that Start returns immediately
+// when the context is already cancelled before Start is called.
+func TestServer_Start_AlreadyCancelledContext(t *testing.T) {
+	t.Setenv("APP_GRPC_PORT", "18082")
+
+	h := handler.NewHealthHandler()
+	s := connectrpc.NewServer(h)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- s.Start(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return within timeout for pre-cancelled context")
+	}
+}
+
+// TestServer_Start_PortAlreadyBound verifies that Start returns a non-nil error
+// when the configured port is already in use.
+// The listener must bind on all interfaces (":0") to conflict with the server's
+// all-interface bind (":PORT"). A loopback-only bind (127.0.0.1:PORT) does not
+// conflict on macOS.
+func TestServer_Start_PortAlreadyBound(t *testing.T) {
+	// Bind on all interfaces with an OS-assigned random port.
+	ln, err := net.Listen("tcp", ":0") //nolint:gosec // test-only ephemeral listener
+	require.NoError(t, err)
+
+	defer ln.Close()
+
+	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok, "expected *net.TCPAddr")
+
+	port := strconv.Itoa(tcpAddr.Port)
+	t.Setenv("APP_GRPC_PORT", port)
+
+	h := handler.NewHealthHandler()
+	s := connectrpc.NewServer(h)
+
+	err = s.Start(context.Background())
+	assert.Error(t, err)
+}

--- a/go-backend/internal/infrastructure/di/wire.go
+++ b/go-backend/internal/infrastructure/di/wire.go
@@ -5,6 +5,8 @@ package di
 import (
 	"context"
 
+	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/connectrpc"
+	crpchandler "github.com/Haya372/web-app-template/go-backend/internal/infrastructure/connectrpc/handler"
 	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/db"
 	"github.com/Haya372/web-app-template/go-backend/internal/infrastructure/http"
 	infraquery "github.com/Haya372/web-app-template/go-backend/internal/infrastructure/query"
@@ -16,6 +18,16 @@ import (
 	queryuser "github.com/Haya372/web-app-template/go-backend/internal/usecase/query/user"
 	"github.com/google/wire"
 )
+
+// Servers holds both the REST and Connect-RPC servers.
+type Servers struct {
+	REST *http.Server
+	GRPC *connectrpc.Server
+}
+
+func newServers(rest *http.Server, grpc *connectrpc.Server) *Servers {
+	return &Servers{REST: rest, GRPC: grpc}
+}
 
 var repositorySet = wire.NewSet(
 	repository.NewUserRepository,
@@ -54,6 +66,12 @@ var httpSet = wire.NewSet(
 	wire.Struct(new(http.Server), "*"),
 )
 
+var connectRPCSet = wire.NewSet(
+	crpchandler.NewHealthHandler,
+	connectrpc.NewServer,
+)
+
+// InitializeServer initialises the REST server only (preserved for backward compatibility).
 func InitializeServer(ctx context.Context) (*http.Server, error) {
 	wire.Build(
 		repositorySet,
@@ -62,6 +80,22 @@ func InitializeServer(ctx context.Context) (*http.Server, error) {
 		querySet,
 		dbSet,
 		httpSet,
+	)
+
+	return nil, nil
+}
+
+// InitializeServers initialises both the REST and Connect-RPC servers.
+func InitializeServers(ctx context.Context) (*Servers, error) {
+	wire.Build(
+		repositorySet,
+		authSet,
+		usecaseSet,
+		querySet,
+		dbSet,
+		httpSet,
+		connectRPCSet,
+		newServers,
 	)
 
 	return nil, nil

--- a/scripts/ports-init.sh
+++ b/scripts/ports-init.sh
@@ -37,7 +37,7 @@ ENV_FILE=".env.local"
 ENV_TMP="${ENV_FILE}.tmp.$$"
 
 if [ -f "$ENV_FILE" ]; then
-  grep -v '^WORKTREE_OFFSET=\|^APP_PORT=\|^VITE_PORT=\|^DB_PORT=\|^CORS_ALLOW_ORIGINS=' "$ENV_FILE" > "$ENV_TMP" || true
+  grep -v '^WORKTREE_OFFSET=\|^APP_PORT=\|^APP_GRPC_PORT=\|^VITE_PORT=\|^DB_PORT=\|^CORS_ALLOW_ORIGINS=' "$ENV_FILE" > "$ENV_TMP" || true
 else
   > "$ENV_TMP"
 fi
@@ -45,10 +45,11 @@ fi
 {
   echo "WORKTREE_OFFSET=$OFFSET"
   echo "APP_PORT=$((8080 + OFFSET))"
+  echo "APP_GRPC_PORT=$((8081 + OFFSET))"
   echo "VITE_PORT=$((3000 + OFFSET))"
   echo "DB_PORT=$((55432 + OFFSET))"
   echo "CORS_ALLOW_ORIGINS=http://localhost:$((3000 + OFFSET))"
 } >> "$ENV_TMP"
 
 mv "$ENV_TMP" "$ENV_FILE"
-echo "Done: APP_PORT=$((8080+OFFSET)) VITE_PORT=$((3000+OFFSET)) DB_PORT=$((55432+OFFSET))"
+echo "Done: APP_PORT=$((8080+OFFSET)) APP_GRPC_PORT=$((8081+OFFSET)) VITE_PORT=$((3000+OFFSET)) DB_PORT=$((55432+OFFSET))"


### PR DESCRIPTION
## 背景・目的

go-backend に Connect-RPC サーバーを追加し、既存 REST サーバー（ポート 8080）と別ポート（8081）で並存させる。  
proto/health/v1/health.proto の生成済みスタブを利用して HealthService.Check ハンドラを実装し、buf curl や Connect クライアントで疎通確認できる状態にする。

関連: #104（親 Issue: #57）

## 変更内容

- `internal/infrastructure/connectrpc/handler/health.go` — `HealthHandler.Check` を実装（`SERVING_STATUS_SERVING` を返す）
- `internal/infrastructure/connectrpc/server.go` — `APP_GRPC_PORT`（デフォルト 8081）でリッスンする Connect-RPC サーバーを追加
- `internal/infrastructure/di/wire.go` — `connectRPCSet` と `InitializeServers` を追加（既存 `InitializeServer` は後方互換のため残す）
- `cmd/server/main.go` — `errgroup` で REST + Connect-RPC を並行起動。`run()` ヘルパーを抽出して deferred shutdown が正しく動作するよう修正
- `.golangci.toml` — domain/usecase 層への `connectrpc.com/connect` インポートを depguard で禁止（ADR-0004 準拠）
- `scripts/ports-init.sh` — ワークツリーポート分離に `APP_GRPC_PORT`（8081 + OFFSET）を追加

## テスト実施結果

| コマンド | 結果 |
|---------|------|
| `make fmt` | ✅ 0 issues |
| `make lint` | ✅ 0 issues |
| `make test-unit` | ✅ 全テストパス（`connectrpc` / `connectrpc/handler` 含む） |

## 関連 issue

Closes #104

## ADR / ドキュメント更新

- ADR-0004（Clean Architecture 依存方向）準拠: depguard ルールで `connectrpc.com/connect` の domain/usecase 層への漏洩を禁止
- ADR-0010（独立ポート方式）準拠: `:8081` で Connect-RPC を起動し、既存 Echo サーバーを変更しない

## 破壊的変更

なし。`InitializeServer`（単数）は保持し、既存コードへの影響はない。