### PR TITLE
chore: fix pre-push gitleaks and add Stop hook for lessons-learned issues

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,6 +42,19 @@
     ]
   },
   "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "agent",
+            "prompt": "Review this conversation. If the task involved significant failures worth documenting—repeated failed attempts, unexpected errors, or approaches that did not work before reaching a solution—create a GitHub Issue to capture the lessons learned. Run: gh issue create --title 'Lessons Learned: [brief description]' --body '[markdown body: what was attempted, what failed and why, how it was resolved]'. Only create an issue for genuine non-trivial failures. Do NOT create one for clean first-attempt successes or simple Q&A sessions.",
+            "timeout": 120,
+            "model": "claude-haiku-4-5-20251001",
+            "statusMessage": "Reviewing task for lessons learned..."
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Skill",
@@ -59,7 +72,7 @@
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
-    "allowUnsandboxedCommands": true,
+    "allowUnsandboxedCommands": false,
     "excludedCommands": ["git", "gh", "docker", "pnpm", "mise", "make"],
     "network": {
       "allowedDomains": [

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# シークレット漏洩チェック（exit code 1 でプッシュをブロック）
-# --staged: ステージ済みファイルを含めてスキャン
-# --redact: ターミナルへのシークレット本文の出力を抑制
-# --verbose: 検出時に該当ファイル・行・ルール名を表示
-# .gitleaksignore が存在する場合、fingerprint に一致した finding は自動的に無視される
-gitleaks protect --staged --redact --verbose
+# Scan commits not yet on any remote for leaked secrets and block the push on detection.
+# --not --remotes: limits git log to local-only commits (new branch or new commits)
+# --redact:        suppress secret values in terminal output
+# --verbose:       show file, line, and rule name on detection
+# .gitleaksignore: findings matching a known fingerprint are silently skipped
+gitleaks git --log-opts="--not --remotes" --redact --verbose --config .gitleaks.toml


### PR DESCRIPTION
## 背景・目的

2つの改善を行う。

1. **pre-push gitleaks の修正**: 従来の `gitleaks protect --staged` はステージ済みファイルのみをスキャンする pre-commit 向けのコマンドであり、コミット履歴に含まれるシークレットを検出できなかった。pre-push フックでは、リモートにまだ存在しないコミットをスキャンする必要がある。
2. **Stop hook の追加**: タスク完了後にうまくいかなかったことがあれば、その内容を自動的に GitHub Issue として起票する仕組みを導入する。

## 変更内容

- `.husky/pre-push`: `gitleaks protect --staged` → `gitleaks git --log-opts="--not --remotes"` に変更。リモートに存在しない全コミットをスキャン対象とすることで、新規ブランチ・既存ブランチどちらにも正しく対応。
- `.claude/settings.json`: `Stop` イベントの agent hook を追加。Haiku モデルが会話を振り返り、重大な失敗（試行錯誤・予期しないエラー・うまくいかなかったアプローチ）があった場合のみ `gh issue create` で Lessons Learned Issue を起票。
- `.claude/settings.json`: `allowUnsandboxedCommands` を `false` に変更。

## テスト実施結果

変更対象は Claude 設定ファイルと husky フックのみ（Go/フロントエンドのソースコード変更なし）のため、該当する make ターゲットなし。

`git push` 時に新しい pre-push フックが実行され、gitleaks によるコミットスキャンが正常に完了したことを確認済み（0 leaks found）。

## 関連 issue

なし

## ADR / ドキュメント更新

なし

## 破壊的変更

なし