### PR TITLE
feat: introduce Semgrep SAST and ESLint for packages/ui

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,3 @@
 DATABASE_DSN=postgres://postgres:postgres@localhost:55432/backend
 AUTH_JWT_SECRET=auth-jwt-secret
+SEMGREP_SEND_METRICS=off

--- a/.github/workflows/ci-packages-ui.yml
+++ b/.github/workflows/ci-packages-ui.yml
@@ -5,6 +5,7 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - "packages/ui/**"
+      - "eslint.config.base.mjs"
       - ".github/workflows/ci-packages-ui.yml"
       - ".github/actions/setup-pnpm-workspace/**"
       - "!**.md"

--- a/.github/workflows/ci-semgrep.yml
+++ b/.github/workflows/ci-semgrep.yml
@@ -1,0 +1,31 @@
+name: ci-semgrep
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: semgrep-sast
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep:1.82
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run Semgrep
+        run: >
+          semgrep scan
+          --config p/golang
+          --config p/typescript
+          --config p/secrets
+          --config p/owasp-top-ten
+          --disable-version-check
+          --metrics=off
+          --error

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,18 @@
+# Dependency directories
+node_modules/
+vendor/
+dist/
+storybook-static/
+
+# Generated files (glob pattern)
+*.gen.ts
+*.gen.go
+
+# Backend generated paths
+go-backend/internal/infrastructure/sqlc/
+go-backend/internal/infrastructure/di/wire_gen.go
+go-backend/internal/infrastructure/grpc/gen/
+go-backend/test/integration/wire_gen.go
+
+# Frontend generated
+apps/react-frontend/src/generated/

--- a/e2e/nginx.e2e.conf
+++ b/e2e/nginx.e2e.conf
@@ -6,7 +6,7 @@ server {
     # Proxy API requests to the backend container (avoids browser CORS issues)
     location /v1/ {
         proxy_pass http://backend:8080;
-        proxy_set_header Host $host;
+        proxy_set_header Host $host; # nosemgrep: generic.nginx.security.request-host-used.request-host-used -- E2E test proxy only; $host is safe in this controlled environment
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/go-backend/internal/infrastructure/connectrpc/server_test.go
+++ b/go-backend/internal/infrastructure/connectrpc/server_test.go
@@ -92,7 +92,7 @@ func TestServer_Start_AlreadyCancelledContext(t *testing.T) {
 // conflict on macOS.
 func TestServer_Start_PortAlreadyBound(t *testing.T) {
 	// Bind on all interfaces with an OS-assigned random port.
-	ln, err := net.Listen("tcp", ":0") //nolint:gosec // test-only ephemeral listener
+	ln, err := net.Listen("tcp", ":0") //nolint:gosec // test-only ephemeral listener // nosemgrep: go.lang.security.audit.net.bind_all.avoid-bind-to-all-interfaces
 	require.NoError(t, err)
 
 	defer ln.Close()

--- a/go-backend/internal/infrastructure/connectrpc/server_test.go
+++ b/go-backend/internal/infrastructure/connectrpc/server_test.go
@@ -92,7 +92,8 @@ func TestServer_Start_AlreadyCancelledContext(t *testing.T) {
 // conflict on macOS.
 func TestServer_Start_PortAlreadyBound(t *testing.T) {
 	// Bind on all interfaces with an OS-assigned random port.
-	ln, err := net.Listen("tcp", ":0") //nolint:gosec // test-only ephemeral listener // nosemgrep: go.lang.security.audit.net.bind_all.avoid-bind-to-all-interfaces
+	// nosemgrep: go.lang.security.audit.net.bind_all.avoid-bind-to-all-interfaces
+	ln, err := net.Listen("tcp", ":0") //nolint:gosec // test-only ephemeral listener
 	require.NoError(t, err)
 
 	defer ln.Close()

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ golangci-lint = "2.8.0"
 node = "24.14.0"
 pnpm = "10.30.3"
 psqldef = "3.9.7"
+semgrep = "1.161.0"
 shellcheck = "0.11.0"
 zizmor = "1.23.1"
 

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -8,7 +8,9 @@ Run from `packages/ui/`:
 
 ```bash
 # Lint (read-only)
-pnpm lint         # biome lint
+pnpm lint         # biome + eslint (react-hooks, jsx-a11y, import-x, unicorn)
+pnpm lint:biome   # biome only
+pnpm lint:eslint  # eslint only
 
 # Format and auto-fix
 pnpm check        # biome check --write

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -1,0 +1,139 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { fixupPluginRules } from "@eslint/compat";
+import importX from "eslint-plugin-import-x";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import reactPlugin from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import unicornPlugin from "eslint-plugin-unicorn";
+import tseslint from "typescript-eslint";
+import { formattingRulesOff } from "../../eslint.config.base.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default tseslint.config(
+	{ ignores: ["dist/**", "storybook-static/**"] },
+
+	// ── Base language options ──────────────────────────────────────────────────
+	{
+		files: ["src/**/*.{ts,tsx}"],
+		languageOptions: {
+			parser: tseslint.parser,
+			parserOptions: {
+				projectService: true,
+				tsconfigRootDir: __dirname,
+			},
+		},
+	},
+
+	// ── React (flat/recommended) ───────────────────────────────────────────────
+	// Provides rules for JSX correctness and React best practices.
+	// eslint-plugin-react v7 uses legacy context APIs removed in ESLint v10;
+	// fixupPluginRules() shims those APIs so the rules work unchanged.
+	{
+		plugins: {
+			react: fixupPluginRules(reactPlugin),
+		},
+		rules: {
+			...reactPlugin.configs.flat.recommended.rules,
+			...reactPlugin.configs.flat["jsx-runtime"].rules, // React 17+ JSX transform — no `import React` needed
+		},
+		settings: {
+			react: {
+				version: "detect",
+			},
+		},
+	},
+
+	// ── React Hooks ───────────────────────────────────────────────────────────
+	// Enforces the Rules of Hooks and exhaustive-deps.
+	reactHooks.configs.flat["recommended-latest"],
+
+	// ── JSX Accessibility (a11y) ──────────────────────────────────────────────
+	// Enforces accessibility best practices for JSX elements.
+	jsxA11y.flatConfigs.recommended,
+
+	// ── Import-X ──────────────────────────────────────────────────────────────
+	// Validates import paths and catches problematic import patterns.
+	// Note: Resolution-based rules are disabled because TypeScript already
+	// validates all import paths and types.
+	importX.configs["flat/recommended"],
+	{
+		rules: {
+			// TypeScript already catches unresolved imports — disable to avoid duplicates.
+			"import-x/no-unresolved": "off",
+			"import-x/namespace": "off",
+			"import-x/default": "off",
+			"import-x/no-named-as-default": "off",
+			"import-x/no-named-as-default-member": "off",
+
+			// Covered by Biome's import sorting (assist.organizeImports).
+			"import-x/order": "off",
+			// Allow missing extensions for TS/TSX — TypeScript resolves them.
+			"import-x/extensions": "off",
+			// Biome enforces no barrel re-exports; ESLint rule too noisy here.
+			"import-x/no-default-export": "off",
+			// Story files use default exports (Storybook meta) — disable the named rule.
+			"import-x/prefer-default-export": "off",
+		},
+	},
+
+	// ── Unicorn (modern JS idioms) ────────────────────────────────────────────
+	// Promotes modern JavaScript patterns and catches common pitfalls.
+	unicornPlugin.configs["flat/recommended"],
+	{
+		rules: {
+			// The project uses common abbreviations (props, fn, ref, etc.).
+			"unicorn/prevent-abbreviations": "off",
+
+			// PascalCase component filenames are a React convention.
+			"unicorn/filename-case": [
+				"error",
+				{
+					cases: {
+						pascalCase: true,
+						camelCase: true,
+						kebabCase: true,
+					},
+				},
+			],
+
+			// `null` is used in React (e.g., conditional rendering, Radix UI).
+			"unicorn/no-null": "off",
+
+			// Array.forEach is idiomatic in this codebase and readable.
+			"unicorn/no-array-for-each": "off",
+
+			// `Array.from` vs spread is a style preference; Biome handles this.
+			"unicorn/prefer-spread": "off",
+
+			// Story files use default exports (Storybook meta pattern).
+			"unicorn/no-anonymous-default-export": "off",
+
+			// CVA and Radix patterns use switch statements; this rule is too strict.
+			"unicorn/no-negated-condition": "off",
+
+			// Ternary nesting is common in JSX; Biome handles formatting complexity.
+			"unicorn/no-nested-ternary": "off",
+
+			// Conflicts with TypeScript's `import type` which Biome already handles.
+			"unicorn/prefer-module": "off",
+
+			// Number constants are intentionally not extracted in all cases.
+			"unicorn/numeric-separators-style": "off",
+
+			// Covered by TypeScript itself — redundant.
+			"unicorn/prefer-number-properties": "off",
+
+			// This is a browser React component library — `window` is idiomatic.
+			"unicorn/prefer-global-this": "off",
+
+			// TypeScript declaration files use `export {}` to make a file a module.
+			"unicorn/require-module-specifiers": "off",
+		},
+	},
+
+	// ── Formatting rules OFF (Biome is the formatter) ────────────────────────
+	// Biome owns all formatting concerns: indentation, quotes, semicolons, etc.
+	formattingRulesOff,
+);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,9 @@
     "build-storybook": "storybook build",
     "typecheck": "tsc --noEmit",
     "format": "biome check --write src/*",
-    "lint": "biome check src/*"
+    "lint": "run-s lint:*",
+    "lint:biome": "biome check src",
+    "lint:eslint": "eslint src/"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "1.3.3",
@@ -35,17 +37,26 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.11",
+    "@eslint/compat": "2.0.5",
+    "@storybook/addon-docs": "10.3.5",
     "@storybook/react-vite": "10.3.5",
     "@tailwindcss/vite": "4.2.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "5.2.0",
+    "eslint": "10.2.0",
+    "eslint-plugin-import-x": "4.16.2",
+    "eslint-plugin-jsx-a11y": "6.10.2",
+    "eslint-plugin-react": "7.37.5",
+    "eslint-plugin-react-hooks": "7.0.1",
+    "eslint-plugin-unicorn": "63.0.0",
     "lint-staged": "16.4.0",
+    "npm-run-all2": "8.0.4",
     "storybook": "10.3.5",
     "tailwindcss": "4.2.2",
     "typescript": "5.9.3",
-    "vite": "8.0.8",
-    "@storybook/addon-docs": "10.3.5"
+    "typescript-eslint": "8.58.1",
+    "vite": "8.0.8"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.11
         version: 2.4.11
+      '@eslint/compat':
+        specifier: 2.0.5
+        version: 2.0.5(eslint@10.2.0(jiti@2.6.1))
       '@storybook/addon-docs':
         specifier: 10.3.5
         version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -226,9 +229,30 @@ importers:
       '@vitejs/plugin-react':
         specifier: 5.2.0
         version: 5.2.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      eslint:
+        specifier: 10.2.0
+        version: 10.2.0(jiti@2.6.1)
+      eslint-plugin-import-x:
+        specifier: 4.16.2
+        version: 4.16.2(@typescript-eslint/utils@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-jsx-a11y:
+        specifier: 6.10.2
+        version: 6.10.2(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-react:
+        specifier: 7.37.5
+        version: 7.37.5(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: 7.0.1
+        version: 7.0.1(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-unicorn:
+        specifier: 63.0.0
+        version: 63.0.0(eslint@10.2.0(jiti@2.6.1))
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
+      npm-run-all2:
+        specifier: 8.0.4
+        version: 8.0.4
       storybook:
         specifier: 10.3.5
         version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -238,6 +262,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: 8.58.1
+        version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 8.0.8
         version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
## 背景・目的

静的解析・セキュリティ検出の強化を目的に、Semgrep SAST を導入し、`packages/ui` に ESLint を追加した（Issue #157）。

- 現状、セキュリティ脆弱性パターン（XSS・SQLi・シークレットリーク等）を機械的に検出する仕組みがなく、コードレビューで見落とされるリスクがあった
- `packages/ui` は Biome のみで ESLint が未設定のため、`apps/react-frontend` で適用している react-hooks や jsx-a11y などの品質ルールが適用されていなかった

## 変更内容

**Semgrep SAST**
- `.semgrepignore` を追加。`node_modules/`・`vendor/`・`dist/`・sqlc / wire / protobuf 生成ファイルを除外
- `.github/workflows/ci-semgrep.yml` を追加。PR トリガーで `p/golang`・`p/typescript`・`p/secrets`・`p/owasp-top-ten` を一括スキャン。`--metrics=off --disable-version-check` でテレメトリ・バージョンチェック通信を無効化
- `mise.toml` に `semgrep = "1.161.0"` を追加
- 既存コードの初回スキャン結果を棚卸し。false positive 2件に `# nosemgrep` コメントを付記

**packages/ui ESLint**
- `packages/ui/eslint.config.mjs` を新規作成。`eslint-plugin-react`・`eslint-plugin-react-hooks`・`eslint-plugin-jsx-a11y`・`eslint-plugin-import-x`・`eslint-plugin-unicorn` を `apps/react-frontend` と同等のルールで設定
- `packages/ui/package.json` の `lint` スクリプトを `run-s lint:*`（biome + eslint）方式に変更
- `.github/workflows/ci-packages-ui.yml` の `paths` に `eslint.config.base.mjs` を追加（ESLint が依存するため）
- `packages/ui/CLAUDE.md` の `pnpm lint` 説明を更新

## テスト実施結果

| 対象 | コマンド | 結果 |
|------|---------|------|
| packages/ui lint (biome + eslint) | `pnpm lint` | ✅ pass（0 errors） |
| CI ワークフロー構文 | `actionlint ci-semgrep.yml ci-packages-ui.yml` | ✅ pass |
| Semgrep スキャン | `semgrep scan --config p/golang ... --metrics=off` | ✅ 0 findings（抑制 2件） |

## 関連 issue

Closes #157

## ADR / ドキュメント更新

- 新規 ADR なし（ツーリング追加のみ、アーキテクチャ上の意思決定を伴わない）
- `packages/ui/CLAUDE.md` 更新済み

## 破壊的変更

なし