### PR TITLE
chore: disable Semgrep CI due to external data transmission risk

### DIFF
--- a/.github/workflows/ci-semgrep.yml
+++ b/.github/workflows/ci-semgrep.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   semgrep:
+    # Disabled: Semgrep fetches remote rulesets (p/golang, p/typescript, etc.) on each run,
+    # which poses a risk of unintended external data transmission.
+    if: false
     name: semgrep-sast
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## 背景・目的

Semgrep は実行時にリモートのルールセット（`p/golang`、`p/typescript` など）を外部サーバーから取得するため、意図しない外部へのデータ送信リスクがある。このリスクを回避するため、CI ジョブを無効化する。

## 変更内容

- `.github/workflows/ci-semgrep.yml` の `semgrep` ジョブに `if: false` を追加して無効化
- 無効化の理由をコメントとして記載

## テスト実施結果

ワークフローファイルのみの変更のため、該当する `make` ターゲットなし。

## 関連 issue

なし

## ADR / ドキュメント更新

なし

## 破壊的変更

なし