### PR TITLE
chore: improve Stop hook for lessons-learned issues

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,10 +47,10 @@
         "hooks": [
           {
             "type": "agent",
-            "prompt": "Review this conversation. If the task involved significant failures worth documenting—repeated failed attempts, unexpected errors, or approaches that did not work before reaching a solution—create a GitHub Issue to capture the lessons learned. Run: gh issue create --title 'Lessons Learned: [brief description]' --body '[markdown body: what was attempted, what failed and why, how it was resolved]'. Only create an issue for genuine non-trivial failures. Do NOT create one for clean first-attempt successes or simple Q&A sessions.",
+            "prompt": "このセッションの会話を日本語でレビューしてください。繰り返しの失敗・予期せぬエラー・解決前に機能しなかったアプローチなど、記録に値する重大な失敗があった場合のみ、以下の手順で親Issueに追記します。単純な一発成功やQ&Aセッションは対象外です。\n\n手順:\n1. `gh issue list --search 'Lessons Learned まとめ' --state open --json number,title` で親Issueを検索する。\n2. 親Issueが存在しない場合: `gh issue create --title 'Lessons Learned まとめ'` で作成し、以下のbodyを設定する:\n```\n## Claude Code セッション教訓一覧\n\n| 状態 | 意味 |\n|------|------|\n| 🔴 `- [ ]` | 未対応 |\n| 🟡 `- [ ]` | 対応策発見済み（docs/rules/skillへの反映が未完了） |\n| 🟢 `- [x]` | docs・rules・skillに反映して再発予防済み |\n\n---\n\n```\n3. 親Issueの本文を取得: `gh issue view <number> --json body -q .body`\n4. 以下の形式で新しい🔴（未対応）項目を本文末尾に追加し、`gh issue edit <number> --body \"<更新された本文>\"` で更新する。\n\nチェックボックスの形式（新規追加は必ず🔴・未チェック）:\n- [ ] 🔴 **[YYYY-MM-DD] 教訓タイトル** - 何を試みたか、何が失敗したか、どう解決したか（簡潔に1〜2文）",
             "timeout": 120,
             "model": "claude-haiku-4-5-20251001",
-            "statusMessage": "Reviewing task for lessons learned..."
+            "statusMessage": "セッションを教訓として記録中..."
           }
         ]
       }


### PR DESCRIPTION
## 背景・目的

Claude Code の Stop hook（セッション終了時に教訓を記録する仕組み）を改善する。

- 以前は失敗のたびに個別 Issue を起票していたため、#165 / #166 / #168 のように重複・類似 Issue が乱立していた
- 親 Issue #170「Lessons Learned まとめ」に集約し、チェックボックスで進捗を管理できるようにする
- 教訓の状態を 3 段階（未対応 🔴 / 対応策発見済み 🟡 / 反映済み 🟢）で管理できるように整理する

## 変更内容

- `Stop` hook のプロンプトを更新
  - 新規 Issue 起票から、既存の親 Issue (#170) へのチェックボックス追記方式に変更
  - 新規追加は必ず 🔴（未対応）で追記
  - 親 Issue が存在しない場合は 3 分類の凡例付きで自動作成
  - 日本語で記録するよう指示を変更
- `statusMessage` を日本語化（「セッションを教訓として記録中...」）

## テスト実施結果

設定ファイルのみの変更のため、該当する make ターゲットなし。JSON の構文は `jq` で検証済み。

## 関連 issue

Closes #170

## ADR / ドキュメント更新

なし

## 破壊的変更

なし