### PR TITLE
feat(vo): strengthen VO validation in go-backend domain layer

### DIFF
--- a/go-backend/go.mod
+++ b/go-backend/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.50.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -92,6 +93,5 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go-backend/internal/domain/entity/user.go
+++ b/go-backend/internal/domain/entity/user.go
@@ -11,10 +11,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-var (
-	errIllegalName = errors.New("illegal name")
-)
-
 type User interface {
 	ID() uuid.UUID
 	Email() string
@@ -83,11 +79,15 @@ func NewUser(email, rawPassword, name string, createdAt time.Time) (User, error)
 		return nil, err
 	}
 
-	if len(name) == 0 {
-		return nil, vo.NewValidationError("name is required", nil, errIllegalName)
+	e, err := vo.NewEmail(email)
+	if err != nil {
+		return nil, err
 	}
 
-	// TODO: implement email validation
+	n, err := vo.NewName(name)
+	if err != nil {
+		return nil, err
+	}
 
 	password, err := vo.NewPassword(rawPassword)
 	if err != nil {
@@ -101,9 +101,9 @@ func NewUser(email, rawPassword, name string, createdAt time.Time) (User, error)
 
 	return &userImpl{
 		id:           id,
-		email:        email,
+		email:        e.String(),
 		passwordHash: passwordHash,
-		name:         name,
+		name:         n.String(),
 		createdAt:    createdAt,
 		status:       vo.UserStatusActive,
 	}, nil

--- a/go-backend/internal/domain/entity/user_test.go
+++ b/go-backend/internal/domain/entity/user_test.go
@@ -19,6 +19,8 @@ func TestUser_HappyCase(t *testing.T) {
 		password  string
 		name      string
 		createdAt time.Time
+		wantEmail string
+		wantName  string
 	}{
 		{
 			testName:  "Success to create User",
@@ -26,6 +28,26 @@ func TestUser_HappyCase(t *testing.T) {
 			password:  "password",
 			name:      "Test",
 			createdAt: time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC),
+			wantEmail: "test@example.com",
+			wantName:  "Test",
+		},
+		{
+			testName:  "email domain is normalised to lowercase",
+			email:     "Test@EXAMPLE.COM",
+			password:  "password",
+			name:      "Test",
+			createdAt: time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC),
+			wantEmail: "Test@example.com",
+			wantName:  "Test",
+		},
+		{
+			testName:  "name with surrounding whitespace is trimmed",
+			email:     "test@example.com",
+			password:  "password",
+			name:      " Alice ",
+			createdAt: time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC),
+			wantEmail: "test@example.com",
+			wantName:  "Alice",
 		},
 	}
 
@@ -34,9 +56,9 @@ func TestUser_HappyCase(t *testing.T) {
 			user, err := entity.NewUser(tt.email, tt.password, tt.name, tt.createdAt)
 
 			require.NoError(t, err)
-			assert.Equal(t, user.Name(), tt.name)
-			assert.Equal(t, user.Email(), tt.email)
-			assert.Equal(t, user.CreatedAt(), tt.createdAt)
+			assert.Equal(t, tt.wantName, user.Name())
+			assert.Equal(t, tt.wantEmail, user.Email())
+			assert.Equal(t, tt.createdAt, user.CreatedAt())
 			assert.Equal(t, vo.UserStatusActive, user.Status())
 
 			err = bcrypt.CompareHashAndPassword(user.PasswordHash(), []byte(tt.password))
@@ -65,6 +87,27 @@ func TestUser_FailureCase(t *testing.T) {
 			email:     "test@example.com",
 			password:  "password",
 			name:      "",
+			createdAt: time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			testName:  "whitespace-only name is rejected",
+			email:     "test@example.com",
+			password:  "password",
+			name:      "   ",
+			createdAt: time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			testName:  "invalid email format is rejected",
+			email:     "not-an-email",
+			password:  "password",
+			name:      "Test",
+			createdAt: time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			testName:  "empty email is rejected",
+			email:     "",
+			password:  "password",
+			name:      "Test",
 			createdAt: time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC),
 		},
 	}

--- a/go-backend/internal/domain/vo/content.go
+++ b/go-backend/internal/domain/vo/content.go
@@ -1,21 +1,45 @@
 package vo
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
 
 type Content string
+
+// maxContentLength is the maximum number of Unicode runes allowed in a Content VO.
+// The DB column is text (no DB-level length constraint); this limit is a business rule.
+const maxContentLength = 10000
 
 var (
 	errIllegalContent = errors.New("illegal content")
 )
 
 // NewContent validates raw and returns a Content value object.
-// Returns a ValidationError if raw is empty.
+// Leading/trailing whitespace is trimmed before validation.
+// Returns a ValidationError if the trimmed value is empty or exceeds maxContentLength runes.
 func NewContent(raw string) (*Content, error) {
-	if raw == "" {
+	trimmed := strings.TrimSpace(raw)
+
+	if trimmed == "" {
 		return nil, NewValidationError("content is required", nil, errIllegalContent)
 	}
 
-	content := Content(raw)
+	if utf8.RuneCountInString(trimmed) > maxContentLength {
+		return nil, NewValidationError(
+			fmt.Sprintf("content must be at most %d characters long", maxContentLength),
+			map[string]any{"max_length": maxContentLength},
+			errIllegalContent,
+		)
+	}
+
+	content := Content(trimmed)
 
 	return &content, nil
+}
+
+func (c Content) String() string {
+	return string(c)
 }

--- a/go-backend/internal/domain/vo/content_test.go
+++ b/go-backend/internal/domain/vo/content_test.go
@@ -1,6 +1,7 @@
 package vo_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Haya372/web-app-template/go-backend/internal/domain/vo"
@@ -10,16 +11,39 @@ import (
 
 func TestContent_HappyCase(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
+		name        string
+		input       string
+		wantContent string
 	}{
 		{
-			name:  "non-empty string creates valid Content VO",
-			input: "Hello, world!",
+			name:        "non-empty string creates valid Content VO",
+			input:       "Hello, world!",
+			wantContent: "Hello, world!",
 		},
 		{
-			name:  "whitespace-only string is treated as valid",
-			input: "   ",
+			name:        "content with leading/trailing whitespace is trimmed",
+			input:       "  hello  ",
+			wantContent: "hello",
+		},
+		{
+			name:        "boundary: exactly 10000-char content",
+			input:       strings.Repeat("a", 10000),
+			wantContent: strings.Repeat("a", 10000),
+		},
+		{
+			name:        "boundary: exactly 10000-char Unicode content",
+			input:       strings.Repeat("あ", 10000),
+			wantContent: strings.Repeat("あ", 10000),
+		},
+		{
+			name:        "trim brings over-limit-before-trim input to exactly 10000 runes and succeeds",
+			input:       "  " + strings.Repeat("a", 10000) + "  ",
+			wantContent: strings.Repeat("a", 10000),
+		},
+		{
+			name:        "boundary: exactly 10000 four-byte emoji runes",
+			input:       strings.Repeat("😀", 10000),
+			wantContent: strings.Repeat("😀", 10000),
 		},
 	}
 
@@ -28,19 +52,37 @@ func TestContent_HappyCase(t *testing.T) {
 			content, err := vo.NewContent(tt.input)
 
 			require.NoError(t, err)
-			assert.Equal(t, vo.Content(tt.input), *content)
+			assert.Equal(t, vo.Content(tt.wantContent), *content)
+			assert.Equal(t, tt.wantContent, content.String())
 		})
 	}
 }
 
 func TestContent_FailureCase(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
+		name        string
+		input       string
+		wantDetails map[string]any
 	}{
 		{
-			name:  "empty string returns ValidationError",
-			input: "",
+			name:        "empty string returns ValidationError",
+			input:       "",
+			wantDetails: nil,
+		},
+		{
+			name:        "whitespace-only string returns ValidationError",
+			input:       "   ",
+			wantDetails: nil,
+		},
+		{
+			name:        "too long: 10001 chars exceeds maximum",
+			input:       strings.Repeat("a", 10001),
+			wantDetails: map[string]any{"max_length": 10000},
+		},
+		{
+			name:        "too long: 10001 Unicode runes exceeds maximum",
+			input:       strings.Repeat("あ", 10001),
+			wantDetails: map[string]any{"max_length": 10000},
 		},
 	}
 
@@ -51,10 +93,10 @@ func TestContent_FailureCase(t *testing.T) {
 			require.Error(t, err)
 			assert.Nil(t, content)
 
-			// Verify the error is a ValidationError (has the expected code)
 			var voErr vo.Error
 			require.ErrorAs(t, err, &voErr)
 			assert.Equal(t, vo.ValidationErrorCode, voErr.Code())
+			assert.Equal(t, tt.wantDetails, voErr.Details())
 		})
 	}
 }

--- a/go-backend/internal/domain/vo/email.go
+++ b/go-backend/internal/domain/vo/email.go
@@ -1,0 +1,59 @@
+package vo
+
+import (
+	"errors"
+	"fmt"
+	"net/mail"
+	"strings"
+	"unicode/utf8"
+)
+
+type Email string
+
+const (
+	maxEmailLength = 256
+)
+
+var (
+	errIllegalEmail = errors.New("illegal email")
+)
+
+func NewEmail(raw string) (*Email, error) {
+	trimmed := strings.TrimSpace(raw)
+
+	if trimmed == "" {
+		return nil, NewValidationError("email is required", nil, errIllegalEmail)
+	}
+
+	if utf8.RuneCountInString(trimmed) > maxEmailLength {
+		return nil, NewValidationError(
+			fmt.Sprintf("email must be at most %d characters long", maxEmailLength),
+			map[string]any{"max_length": maxEmailLength},
+			errIllegalEmail,
+		)
+	}
+
+	// addr.Address is the normalised bare address extracted by the parser.
+	// Requiring equality with the trimmed input rejects display-name forms,
+	// quoted local parts, and comments — only plain addr@domain strings pass.
+	addr, err := mail.ParseAddress(trimmed)
+	if err != nil || addr.Address != trimmed {
+		return nil, NewValidationError("invalid email format", nil, errIllegalEmail)
+	}
+
+	// Domain is case-insensitive per RFC 5321 §2.4; normalise to lowercase.
+	// The local part is case-preserving.
+	// Use addr.Address (the parsed, validated form) as the source to make the
+	// data-flow dependency explicit and resilient to future changes.
+	const atSignParts = 2
+
+	parts := strings.SplitN(addr.Address, "@", atSignParts)
+	normalised := parts[0] + "@" + strings.ToLower(parts[1])
+	email := Email(normalised)
+
+	return &email, nil
+}
+
+func (e Email) String() string {
+	return string(e)
+}

--- a/go-backend/internal/domain/vo/email_test.go
+++ b/go-backend/internal/domain/vo/email_test.go
@@ -1,0 +1,119 @@
+package vo_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Haya372/web-app-template/go-backend/internal/domain/vo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmail_HappyCase(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantEmail string
+	}{
+		{
+			name:      "valid email",
+			input:     "user@example.com",
+			wantEmail: "user@example.com",
+		},
+		{
+			name:      "email with plus tag",
+			input:     "user+tag@sub.domain.com",
+			wantEmail: "user+tag@sub.domain.com",
+		},
+		{
+			name:      "boundary: exactly 256-char valid email",
+			input:     strings.Repeat("a", 244) + "@example.com", // 244 + 12 = 256 chars
+			wantEmail: strings.Repeat("a", 244) + "@example.com",
+		},
+		{
+			name:      "whitespace-padded email is trimmed",
+			input:     " user@example.com ",
+			wantEmail: "user@example.com",
+		},
+		{
+			name:      "subdomain with hyphens and numbers",
+			input:     "user@mail-server.co.jp",
+			wantEmail: "user@mail-server.co.jp",
+		},
+		{
+			name:      "uppercase domain is normalised to lowercase",
+			input:     "user@EXAMPLE.COM",
+			wantEmail: "user@example.com",
+		},
+		{
+			name:      "mixed-case local part is preserved",
+			input:     "User@example.com",
+			wantEmail: "User@example.com",
+		},
+		{
+			name:      "whitespace trimming and domain normalisation compose correctly",
+			input:     " user@EXAMPLE.COM ",
+			wantEmail: "user@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			email, err := vo.NewEmail(tt.input)
+
+			require.NoError(t, err)
+			assert.NotNil(t, email)
+			assert.Equal(t, vo.Email(tt.wantEmail), *email)
+			assert.Equal(t, tt.wantEmail, email.String())
+		})
+	}
+}
+
+func TestEmail_FailureCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+		},
+		{
+			name:  "whitespace only",
+			input: "   ",
+		},
+		{
+			name:  "no at sign",
+			input: "notanemail",
+		},
+		{
+			name:  "missing domain",
+			input: "user@",
+		},
+		{
+			name:  "missing local part",
+			input: "@domain.com",
+		},
+		{
+			name:  "display name format rejected",
+			input: `"Name" <user@example.com>`,
+		},
+		{
+			name:  "too long: 257 chars",
+			input: strings.Repeat("a", 245) + "@example.com", // 245 + 12 = 257 chars
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			email, err := vo.NewEmail(tt.input)
+
+			require.Error(t, err)
+			assert.Nil(t, email)
+
+			var voErr vo.Error
+			require.ErrorAs(t, err, &voErr)
+			assert.Equal(t, vo.ValidationErrorCode, voErr.Code())
+		})
+	}
+}

--- a/go-backend/internal/domain/vo/name.go
+++ b/go-backend/internal/domain/vo/name.go
@@ -1,0 +1,42 @@
+package vo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type Name string
+
+const (
+	maxNameLength = 256
+)
+
+var (
+	errIllegalName = errors.New("illegal name")
+)
+
+func NewName(raw string) (*Name, error) {
+	trimmed := strings.TrimSpace(raw)
+
+	if trimmed == "" {
+		return nil, NewValidationError("name is required", nil, errIllegalName)
+	}
+
+	if utf8.RuneCountInString(trimmed) > maxNameLength {
+		return nil, NewValidationError(
+			fmt.Sprintf("name must be at most %d characters long", maxNameLength),
+			map[string]any{"max_length": maxNameLength},
+			errIllegalName,
+		)
+	}
+
+	name := Name(trimmed)
+
+	return &name, nil
+}
+
+func (n Name) String() string {
+	return string(n)
+}

--- a/go-backend/internal/domain/vo/name_test.go
+++ b/go-backend/internal/domain/vo/name_test.go
@@ -1,0 +1,102 @@
+package vo_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Haya372/web-app-template/go-backend/internal/domain/vo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestName_HappyCase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+	}{
+		{
+			name:     "valid ASCII name",
+			input:    "Alice",
+			wantName: "Alice",
+		},
+		{
+			name:     "Japanese name",
+			input:    "\u5c71\u7530 \u592a\u90ce",
+			wantName: "\u5c71\u7530 \u592a\u90ce",
+		},
+		{
+			name:     "name with leading/trailing whitespace is trimmed",
+			input:    " Bob ",
+			wantName: "Bob",
+		},
+		{
+			name:     "boundary: exactly 256-char name",
+			input:    strings.Repeat("a", 256),
+			wantName: strings.Repeat("a", 256),
+		},
+		{
+			name:     "boundary: exactly 256-char Unicode name",
+			input:    strings.Repeat("あ", 256),
+			wantName: strings.Repeat("あ", 256),
+		},
+		{
+			name:     "trim brings 258-char input to 256 chars and succeeds",
+			input:    " " + strings.Repeat("a", 256) + " ",
+			wantName: strings.Repeat("a", 256),
+		},
+		{
+			name:     "4-byte emoji runes counted correctly at boundary",
+			input:    strings.Repeat("😀", 256),
+			wantName: strings.Repeat("😀", 256),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, err := vo.NewName(tt.input)
+
+			require.NoError(t, err)
+			assert.NotNil(t, name)
+			assert.Equal(t, vo.Name(tt.wantName), *name)
+			assert.Equal(t, tt.wantName, name.String())
+		})
+	}
+}
+
+func TestName_FailureCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+		},
+		{
+			name:  "whitespace only",
+			input: "   ",
+		},
+		{
+			name:  "too long ASCII: 257 chars",
+			input: strings.Repeat("a", 257),
+		},
+		{
+			name:  "too long Unicode: 257 runes",
+			input: strings.Repeat("あ", 257),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, err := vo.NewName(tt.input)
+
+			require.Error(t, err)
+			assert.Nil(t, name)
+
+			var voErr vo.Error
+			require.ErrorAs(t, err, &voErr)
+			assert.Equal(t, vo.ValidationErrorCode, voErr.Code())
+		})
+	}
+}

--- a/go-backend/internal/domain/vo/password.go
+++ b/go-backend/internal/domain/vo/password.go
@@ -3,12 +3,17 @@ package vo
 import (
 	"errors"
 	"fmt"
+	"unicode/utf8"
 )
 
 type Password string
 
 const (
+	// minimumPasswordLength is measured in Unicode code points (runes) for user-visible character count.
 	minimumPasswordLength = 8
+	// maximumPasswordLength is measured in bytes because bcrypt truncates input at 72 bytes;
+	// capping here prevents silent truncation that would make 73+ byte passwords indistinguishable.
+	maximumPasswordLength = 72
 )
 
 var (
@@ -16,12 +21,27 @@ var (
 )
 
 func NewPassword(raw string) (*Password, error) {
-	if len(raw) < minimumPasswordLength {
+	// minimum is measured in runes (user-visible characters)
+	if utf8.RuneCountInString(raw) < minimumPasswordLength {
 		return nil, NewValidationError(
 			fmt.Sprintf("password must be at least %d characters long", minimumPasswordLength), nil, errIllegalPasswordLength)
+	}
+
+	// maximum is measured in bytes because bcrypt truncates at 72 bytes
+	if len(raw) > maximumPasswordLength {
+		return nil, NewValidationError(
+			fmt.Sprintf("password must be at most %d bytes long", maximumPasswordLength),
+			map[string]any{"max_length": maximumPasswordLength},
+			errIllegalPasswordLength)
 	}
 
 	password := Password(raw)
 
 	return &password, nil
+}
+
+// String implements fmt.Stringer and returns a masked value to prevent
+// accidental password exposure in logs or error messages.
+func (p Password) String() string {
+	return "[REDACTED]"
 }

--- a/go-backend/internal/domain/vo/password_test.go
+++ b/go-backend/internal/domain/vo/password_test.go
@@ -1,6 +1,7 @@
 package vo_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Haya372/web-app-template/go-backend/internal/domain/vo"
@@ -14,8 +15,16 @@ func TestPassword_HappyCase(t *testing.T) {
 		input string
 	}{
 		{
-			name:  "correct password",
-			input: "password",
+			name:  "boundary: exactly 8 chars (minimum)",
+			input: "pass1234",
+		},
+		{
+			name:  "boundary: exactly 72 bytes (maximum ASCII)",
+			input: strings.Repeat("a", 72),
+		},
+		{
+			name:  "boundary: 8 multi-byte runes satisfies minimum",
+			input: strings.Repeat("あ", 8), // 8 runes = 24 bytes, passes rune-based min check
 		},
 	}
 
@@ -38,6 +47,14 @@ func TestPassword_FailureCase(t *testing.T) {
 			name:  "password length under 8 characters",
 			input: "passwor",
 		},
+		{
+			name:  "too long: 73 bytes exceeds maximum",
+			input: strings.Repeat("a", 73),
+		},
+		{
+			name:  "too long: multi-byte input exceeds 72 bytes even if fewer runes",
+			input: strings.Repeat("あ", 25), // 25 runes = 75 bytes, exceeds byte limit
+		},
 	}
 
 	for _, tt := range tests {
@@ -46,6 +63,26 @@ func TestPassword_FailureCase(t *testing.T) {
 
 			require.Error(t, err)
 			assert.Nil(t, password)
+
+			var voErr vo.Error
+			require.ErrorAs(t, err, &voErr)
+			assert.Equal(t, vo.ValidationErrorCode, voErr.Code())
 		})
 	}
+}
+
+func TestPassword_MaxLengthErrorDetails(t *testing.T) {
+	_, err := vo.NewPassword(strings.Repeat("a", 73))
+
+	require.Error(t, err)
+
+	var voErr vo.Error
+	require.ErrorAs(t, err, &voErr)
+	assert.Equal(t, map[string]any{"max_length": 72}, voErr.Details())
+}
+
+func TestPassword_String(t *testing.T) {
+	password, err := vo.NewPassword("password")
+	require.NoError(t, err)
+	assert.Equal(t, "[REDACTED]", password.String())
 }

--- a/go-backend/internal/domain/vo/permission.go
+++ b/go-backend/internal/domain/vo/permission.go
@@ -1,9 +1,76 @@
 package vo
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
 // Permission represents a fine-grained access right using the "<resource>:<action>" format.
 type Permission string
 
 const (
 	PermissionUsersList   Permission = "users:list"
 	PermissionUsersCreate Permission = "users:create"
+
+	// maxPermissionLength corresponds to the DB schema: permissions.code varchar(128).
+	maxPermissionLength = 128
 )
+
+var errIllegalPermission = errors.New("illegal permission")
+
+// NewPermission validates raw and returns a Permission value object.
+// Permission is an internal code value; no whitespace trimming is applied
+// (leading/trailing spaces are treated as invalid).
+// The format must be "<resource>:<action>" where both parts are non-empty.
+func NewPermission(raw string) (*Permission, error) {
+	if raw == "" {
+		return nil, NewValidationError("permission is required", nil, errIllegalPermission)
+	}
+
+	// Permission is an internal code value; whitespace is not trimmed and is treated as invalid.
+	if strings.TrimSpace(raw) != raw {
+		return nil, NewValidationError(
+			"permission must be in format 'resource:action'",
+			nil,
+			errIllegalPermission,
+		)
+	}
+
+	if utf8.RuneCountInString(raw) > maxPermissionLength {
+		return nil, NewValidationError(
+			fmt.Sprintf("permission must be at most %d characters long", maxPermissionLength),
+			map[string]any{"max_length": maxPermissionLength},
+			errIllegalPermission,
+		)
+	}
+
+	// "<resource>:<action>" format: exactly one colon, non-empty parts on both sides.
+	if strings.Count(raw, ":") != 1 {
+		return nil, NewValidationError(
+			"permission must be in format 'resource:action'",
+			nil,
+			errIllegalPermission,
+		)
+	}
+
+	const colonParts = 2
+
+	parts := strings.SplitN(raw, ":", colonParts)
+	if parts[0] == "" || parts[1] == "" {
+		return nil, NewValidationError(
+			"permission must be in format 'resource:action'",
+			nil,
+			errIllegalPermission,
+		)
+	}
+
+	permission := Permission(raw)
+
+	return &permission, nil
+}
+
+func (p Permission) String() string {
+	return string(p)
+}

--- a/go-backend/internal/domain/vo/permission_test.go
+++ b/go-backend/internal/domain/vo/permission_test.go
@@ -1,0 +1,98 @@
+package vo_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Haya372/web-app-template/go-backend/internal/domain/vo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermission_HappyCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "valid permission",
+			input: "users:list",
+		},
+		{
+			name:  "valid permission with create action",
+			input: "users:create",
+		},
+		{
+			name:  "boundary: exactly 128-char permission",
+			input: strings.Repeat("a", 63) + ":" + strings.Repeat("b", 64), // 63 + 1 + 64 = 128
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			permission, err := vo.NewPermission(tt.input)
+
+			require.NoError(t, err)
+			assert.NotNil(t, permission)
+			assert.Equal(t, vo.Permission(tt.input), *permission)
+			assert.Equal(t, tt.input, permission.String())
+		})
+	}
+}
+
+func TestPermission_FailureCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+		},
+		{
+			name:  "no colon separator",
+			input: "userslist",
+		},
+		{
+			name:  "missing resource part",
+			input: ":action",
+		},
+		{
+			name:  "missing action part",
+			input: "resource:",
+		},
+		{
+			name:  "too long: 129 chars",
+			input: strings.Repeat("a", 64) + ":" + strings.Repeat("b", 64), // 64 + 1 + 64 = 129
+		},
+		{
+			name:  "multiple colons rejected",
+			input: "users:list:read",
+		},
+		{
+			name:  "colon only",
+			input: ":",
+		},
+		{
+			name:  "leading space treated as invalid (no TrimSpace)",
+			input: " users:list",
+		},
+		{
+			name:  "trailing space treated as invalid (no TrimSpace)",
+			input: "users:list ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			permission, err := vo.NewPermission(tt.input)
+
+			require.Error(t, err)
+			assert.Nil(t, permission)
+
+			var voErr vo.Error
+			require.ErrorAs(t, err, &voErr)
+			assert.Equal(t, vo.ValidationErrorCode, voErr.Code())
+		})
+	}
+}

--- a/go-backend/internal/usecase/query/post/list_posts_usecase.go
+++ b/go-backend/internal/usecase/query/post/list_posts_usecase.go
@@ -23,8 +23,8 @@ var (
 )
 
 type listPostsUseCaseImpl struct {
-	tracer          trace.Tracer
-	logger          common.Logger
+	tracer           trace.Tracer
+	logger           common.Logger
 	postQueryService PostQueryService
 }
 


### PR DESCRIPTION
## 背景・目的

go-backend のドメイン層における Value Object (VO) のバリデーションを強化し、不正な値がドメイン層に侵入できないようにします。
Issue #171 の対応として、新規 VO の追加と既存 VO の拡充を行います。

## 変更内容

- **Email VO 追加** (`vo/email.go`): `net/mail.ParseAddress` を使ったフォーマット検証、ドメイン部の小文字正規化（RFC 5321 §2.4）、最大256ルーン制限
- **Name VO 追加** (`vo/name.go`): 前後空白トリミング、最大256ルーン制限
- **Password VO 拡充** (`vo/password.go`): bcrypt の72バイト上限に対応した最大バイト数チェック追加、`String()` で `[REDACTED]` を返すことでログ漏洩防止
- **Content VO 拡充** (`vo/content.go`): 前後空白トリミング、最大10000ルーン制限（ビジネスルール）
- **Permission VO 拡充** (`vo/permission.go`): `NewPermission` コンストラクタ追加、`<resource>:<action>` 形式チェック、最大128ルーン制限（DB スキーマ対応）
- **entity/user.go リファクタリング**: `NewUser` で `vo.NewEmail` / `vo.NewName` を使用するよう修正（直前まで `TODO: implement email validation` を残していた箇所）

## テスト実施結果

| コマンド | 結果 |
|---|---|
| `golangci-lint run -c .golangci.toml ./...` | ✅ 0 issues |
| `go test ./internal/domain/vo/...` | ✅ ok |
| `go test ./internal/domain/entity/...` | ✅ ok |
| `go test ./internal/domain/aggregate/...` | ✅ ok |

## 関連 issue

Closes #171

## ADR / ドキュメント更新

なし（既存 ADR-0006 エラーコントラクトに準拠した実装）

## 破壊的変更

なし（VO コンストラクタの追加・強化のみ。公開 API ルートの変更なし）