### PR TITLE
chore: reflect sandbox CLI constraint workarounds in docs/skills/settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,11 @@
       }
     ]
   },
+  "env": {
+    "GOCACHE": "/tmp/claude/gocache",
+    "SEMGREP_LOG_FILE": "/tmp/claude/semgrep.log",
+    "SEMGREP_VERSION_CACHE_PATH": "/tmp/claude/semgrep_cache"
+  },
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -34,16 +34,16 @@ Infer the following from the commit history and diff:
 
 ### 3. Check test evidence
 
-Identify which `make` targets are relevant to the changes:
+Identify which commands are relevant to the changes:
 
-| Changed area | Required targets |
+| Changed area | Required commands |
 |---|---|
-| Go source code | `make fmt && make lint && make test-unit` |
-| Integration paths | `make test-integration` |
-| DB schema / queries | `make generate && make migrate-local` |
-| Frontend (React) | `pnpm lint && pnpm test` (run from `apps/react-frontend/`) |
+| Go source code | `cd go-backend && golangci-lint run -c .golangci.toml --fix && golangci-lint run -c .golangci.toml && go test ./...` |
+| Integration paths | `cd go-backend && go test ./... -tags=integration` |
+| DB schema / queries | `cd go-backend && make generate && make migrate-local` |
+| Frontend (React) | `cd apps/react-frontend && pnpm lint && pnpm test` |
 
-Run the relevant targets and report the results. If a target fails, fix the issue before creating the PR. Do **not** prompt the user for permission to run tests — execute them autonomously.
+Run the relevant commands and report the results. If a command fails, fix the issue before creating the PR. Do **not** prompt the user for permission to run tests — execute them autonomously.
 
 ### 4. Handle breaking API changes
 

--- a/.claude/skills/implement-tdd/backend-context.md
+++ b/.claude/skills/implement-tdd/backend-context.md
@@ -17,12 +17,12 @@ already written — make them green."
 
 Run tests:
 ```bash
-make test-unit
+cd go-backend && go test ./...
 ```
 
 If integration paths were changed:
 ```bash
-make test-integration
+cd go-backend && go test ./... -tags=integration
 ```
 
 ## Review prompt (Refactor)
@@ -42,18 +42,18 @@ Design constraints: <ADR references and architectural constraints>"
 ## Quality gate
 
 ```bash
-make fmt && make lint && make test-unit
+cd go-backend && golangci-lint run -c .golangci.toml --fix && golangci-lint run -c .golangci.toml && go test ./...
 ```
 
 If integration paths were changed:
 ```bash
-make test-integration
+cd go-backend && go test ./... -tags=integration
 ```
 
 ## Coverage check
 
 ```bash
-make test-coverage
+cd go-backend && go test ./... -tags=integration -coverprofile=coverage.out && grep -F -v -f .coverageignore coverage.out > coverage.tmp && mv coverage.tmp coverage.out
 ```
 
 If any package touched by this PR shows decreased coverage compared to `main`, add tests before proceeding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,4 +26,27 @@ See each workspace's `CLAUDE.md` for workspace-specific commands and architectur
 
 Format: `<type>(optional-scope): summary (#issue)` — e.g., `feat: add telemetry (#12)`
 
-PR descriptions must include: motivation, test evidence (`make` targets run), linked issues, and any ADR/docs updates. Breaking API changes require a note in `docs/operations`.
+PR descriptions must include: motivation, test evidence (make targets or equivalent commands run), linked issues, and any ADR/docs updates. Breaking API changes require a note in `docs/operations`.
+
+## Sandbox environment notes
+
+Claude Code runs in a sandboxed environment. Use these workarounds for known constraints:
+
+| Constraint | Workaround |
+|-----------|-----------|
+| Edit tool cannot modify `.github/workflows/` files | Use Bash heredoc: `cat > file << 'EOF' ... EOF` |
+| Semgrep blocked from writing to HOME | Env vars set in `.claude/settings.json` redirect logs/cache to `/tmp/claude/` |
+| `pnpm add` / `pnpm install` are denied | Edit `package.json` manually, ask user to run install locally. `pnpm run`/`lint`/`test` work normally |
+| `make` may fail to find Makefile when CWD ≠ repo root | Use `cd go-backend && make ...` or run direct commands below |
+| Go test cache write denied | `GOCACHE=/tmp/claude/gocache` is set in `.claude/settings.json` |
+
+### make target equivalents (run from `go-backend/`)
+
+| make target | Direct command |
+|---|---|
+| `make fmt` | `golangci-lint run -c .golangci.toml --fix` |
+| `make lint` | `golangci-lint run -c .golangci.toml` |
+| `make test-unit` | `go test ./...` |
+| `make test-integration` | `go test ./... -tags=integration` |
+| `make test-coverage` | `go test ./... -tags=integration -coverprofile=coverage.out && grep -F -v -f .coverageignore coverage.out > coverage.tmp && mv coverage.tmp coverage.out` |
+| `make generate` | See `go-backend/Makefile` for full sequence (sqlc → buf → oapi-codegen → mockgen → wire) |


### PR DESCRIPTION
## 背景・目的

Claude Codeのサンドボックス環境で発生する5件のCLI制約について、回避策が判明済みにもかかわらず docs・skills・settings への反映が未完了のため、新セッションで同じ問題に遭遇するリスクがあった。本PRでこれらを全て反映し再発を防止する。(参照: #178)

## 変更内容

- **`.claude/settings.json`**: `env` フィールドを追加し、`GOCACHE`・`SEMGREP_LOG_FILE`・`SEMGREP_VERSION_CACHE_PATH` を `/tmp/claude/` 配下に設定
- **`CLAUDE.md`（ルート）**: 「Sandbox environment notes」セクションを追加。5件の制約と回避策の対応表、および `make` ターゲットの直接コマンド等価表を記載
- **`.claude/skills/implement-tdd/backend-context.md`**: `make test-unit`・`make lint`・`make test-coverage` 等を `cd go-backend && go test ./...` 等の直接コマンドに置換
- **`.claude/skills/create-pr/SKILL.md`**: テスト証拠テーブルの `make` ターゲットを直接コマンドに置換

## テスト実施結果

変更対象はすべて docs・設定ファイル・スキルファイルのみ（Go ソースコード・フロントエンドコードの変更なし）。自動テストの実行対象なし。

## 関連 issue

Closes #178

## ADR / ドキュメント更新

- `CLAUDE.md`（ルート）: 「Sandbox environment notes」セクションを新規追加

## 破壊的変更

なし