### PR TITLE
chore(next-frontend): add CI workflow, lint-staged, and husky pre-commit

### DIFF
--- a/.github/workflows/ci-apps-next-frontend.yml
+++ b/.github/workflows/ci-apps-next-frontend.yml
@@ -1,0 +1,73 @@
+name: ci-apps-next-frontend
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "apps/next-frontend/**"
+      - ".github/workflows/ci-apps-next-frontend.yml"
+      - ".github/actions/setup-pnpm-workspace/**"
+      - "!**.md"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: apps/next-frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm-workspace
+      - name: Lint
+        run: pnpm lint
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: apps/next-frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm-workspace
+      - name: Test
+        run: pnpm test
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: apps/next-frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm-workspace
+      - name: Build
+        run: pnpm build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,6 +8,11 @@ if git diff --cached --name-only | grep -q "^apps/react-frontend/"; then
   cd "$ROOT"
 fi
 
+if git diff --cached --name-only | grep -q "^apps/next-frontend/"; then
+  cd "$ROOT/apps/next-frontend" && pnpm lint-staged
+  cd "$ROOT"
+fi
+
 if git diff --cached --name-only | grep -q "^packages/ui/"; then
   cd "$ROOT/packages/ui" && pnpm lint-staged
   cd "$ROOT"

--- a/apps/next-frontend/package.json
+++ b/apps/next-frontend/package.json
@@ -16,7 +16,8 @@
     "fmt": "run-s fmt:*",
     "fmt:biome": "biome check --write src",
     "fmt:eslint": "eslint --fix src",
-    "fmt:knip": "knip --fix"
+    "fmt:knip": "knip --fix",
+    "lint-staged": "lint-staged"
   },
   "dependencies": {
     "next": "16.2.4",
@@ -43,10 +44,17 @@
     "eslint-plugin-unicorn": "63.0.0",
     "jsdom": "28.1.0",
     "knip": "5.88.1",
+    "lint-staged": "16.4.0",
     "npm-run-all2": "8.0.4",
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.0",
     "vitest": "4.1.5"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "pnpm eslint --fix",
+      "pnpm biome check --write"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       knip:
         specifier: 5.88.1
         version: 5.88.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(typescript@6.0.3)
+      lint-staged:
+        specifier: 16.4.0
+        version: 16.4.0
       npm-run-all2:
         specifier: 8.0.4
         version: 8.0.4


### PR DESCRIPTION
## 背景・目的

#191 で導入された `apps/next-frontend`（Next.js 16 App Router）に、`apps/react-frontend` と同等の自動化基盤が整備されていなかった。このままでは next-frontend 側のコード変更が CI で検証されず、commit 前の自動整形も走らない状態が続いていた（#192）。

## 変更内容

- **`.github/workflows/ci-apps-next-frontend.yml`** を新規追加
  - トリガー: `apps/next-frontend/**`, `pnpm-lock.yaml`, `package.json`, workflow ファイル自身, `\!**.md`
  - ジョブ構成: `lint` → `test` と `build`（`test`/`build` は `needs: lint` で並列実行）
  - `actions/checkout` の SHA pinning / `permissions: contents: read` / composite action `setup-pnpm-workspace` は `ci-apps-react-frontend.yml` を完全踏襲
- **`apps/next-frontend/package.json`** を更新
  - `scripts.lint-staged` を追加
  - `devDependencies` に `lint-staged: 16.4.0` を追加（react-frontend と同バージョン）
  - トップレベル `lint-staged` 設定 `{ "*.{ts,tsx}": ["pnpm eslint --fix", "pnpm biome check --write"] }` を追加
- **`.husky/pre-commit`** を更新
  - `apps/react-frontend/` ブロックの直後に `apps/next-frontend/` 用の grep 判定ブロックを追加
- **`pnpm-lock.yaml`** に `lint-staged 16.4.0` のエントリを追加

## テスト実施結果

| コマンド | 結果 |
|---------|------|
| `pnpm lint` (apps/next-frontend) | ✅ 0 errors |
| `pnpm test:agent` (apps/next-frontend) | ✅ 1 passed (1) |

## 関連 issue

Closes #192

## ADR / ドキュメント更新

なし。既存パターン（`ci-apps-react-frontend.yml`, `apps/react-frontend/package.json`, `.husky/pre-commit`）の踏襲のみ。

## 破壊的変更

なし。新規 CI ワークフローの追加と設定ファイルの変更のみ。

---

**merge 後の TODO（リポジトリ管理者）:** GitHub UI の branch protection に以下の Required status checks を追加してください:
- `ci-apps-next-frontend / lint`
- `ci-apps-next-frontend / test`
- `ci-apps-next-frontend / build`